### PR TITLE
Add blit (copy) functionality

### DIFF
--- a/jimp.js
+++ b/jimp.js
@@ -164,6 +164,16 @@ Jimp.prototype.scan = function (x, y, w, h, cb) {
 };
 
 /**
+ * Returns the pixel index in the bitmap
+ * @param x the x coordinate
+ * @param y the y coordinate
+ * @returns the index of the pixel
+*/
+Jimp.prototype.getPixelIndex = function (x, y) {
+    return (this.bitmap.width * y + x) << 2;
+};
+
+/**
  * Crops the image at a given point to a give size
  * @param x the x coordinate to crop form
  * @param y the y coordiante to crop form
@@ -188,6 +198,28 @@ Jimp.prototype.crop = function (x, y, w, h) {
     this.bitmap.data = new Buffer(bitmap);
     this.bitmap.width = w;
     this.bitmap.height = h;
+    
+    return this;
+};
+
+/**
+ * Copies rectangle of pixels from current image to dst
+ * @param dst destination Jimp instance
+ * @param sx source x
+ * @param sy source y
+ * @param w width
+ * @param h height
+ * @param dx destination x
+ * @param dy destination y
+ * @returns this for chaining of methods
+*/
+Jimp.prototype.blit = function (dst, sx, sy, w, h, dx, dy) {
+    this.scan(sx, sy, w, h, function(x, y, idx) {
+        var dstIdx = dst.getPixelIndex(dx+x-sx, dy+y-sy)
+        dst.bitmap.data[dstIdx] = this.bitmap.data[idx];
+        dst.bitmap.data[dstIdx+1] = this.bitmap.data[idx+1];
+        dst.bitmap.data[dstIdx+2] = this.bitmap.data[idx+2];
+    });
     
     return this;
 };


### PR DESCRIPTION
Also adds a function that returns the index of the pixel in the bitmap given its coordinates

    var lenna = new Jimp("lenna.png", function(){
	    this.blit(this, 247, 235, 98, 136, 0, 0)
	    .write("lennatest.png");
    });

The snippet above copies lenna's face to 0,0 and writes that file.

I've not tested this in much depth, but from what i've seen, corner cases or out of bounds modifications don't break the lib. I'm all for sanity checks though if you want them.