### PR TITLE
Color modifications: hue, saturation, lightness and more

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "mime": "^1.3.4",
     "pngjs2": "^1.2.0",
     "read-chunk": "^1.0.1",
-    "stream-to-buffer": "^0.1.0"
+    "stream-to-buffer": "^0.1.0",
+    "tinycolor2": "^1.1.2"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Added a way to apply color modifications to images. Most of modifications are done through [TinyColor](https://github.com/bgrins/TinyColor), which is a small open source color manipulation library. However, I have added few of my custom modifiers as well.

Instead of having `image.hue()`, `image.saturate()` etc. as separate methods, I decided to have just one `image.color()` method which handles multiple modifications at once:

```javascript
var output = new Jimp('dice.png', function (err, image) {
  this.resize(600, Jimp.AUTO).color([
    { apply: 'hue', params: [ -90 ] },
    { apply: 'lighten', params: [ 50 ] },
    { apply: 'xor', params: [ '#06D' ] }
  ]).write(filePath.replace('.png', 'dice--out.png'));
});
```

Below is the list of available modifiers:

modifier | description
------------- | -------------
**lighten** {amount} | Lighten the color a given amount, from 0 to 100. Providing 100 will always return white (works through [TinyColor](https://github.com/bgrins/TinyColor))
**brighten** {amount} | Brighten the color a given amount, from 0 to 100 (works through [TinyColor](https://github.com/bgrins/TinyColor))
**darken** {amount} | Darken the color a given amount, from 0 to 100. Providing 100 will always return black (works through [TinyColor](https://github.com/bgrins/TinyColor))
**desaturate** {amount} | Desaturate the color a given amount, from 0 to 100. Providing 100 will is the same as calling greyscale (works through [TinyColor](https://github.com/bgrins/TinyColor))
**saturate** {amount} | Saturate the color a given amount, from 0 to 100 (works through [TinyColor](https://github.com/bgrins/TinyColor))
**greyscale** {amount} |   Completely desaturates a color into greyscale (works through [TinyColor](https://github.com/bgrins/TinyColor))
**spin** {degree} |    Spin the hue a given amount, from -360 to 360. Calling with 0, 360, or -360 will do nothing - since it sets the hue back to what it was before. (works through [TinyColor](https://github.com/bgrins/TinyColor))
**hue** {degree} |   Alias for **spin**
**mix** {color, amount} |   Mixes colors by their RGB component values. Amount is opacity of overlaying color
 **tint** {amount} | Same as applying **mix** with white color 
 **shade** {amount} | Same as applying **mix** with black color 
 **xor** {color} | Treats the two colors as bitfields and applies an XOR operation to the red, green, and blue components
 **red** {amount} | Modify Red component by a given amount 
 **green** {amount} | Modify Green component by a given amount 
 **blue** {amount} | Modify Blue component by a given amount 

