### PR TITLE
Stop the test directory from being published to NPM

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,4 @@
+.project
+.idea
+*.iml
+test/


### PR DESCRIPTION
Hi there,
I'm sending this pull request, because when we pull down your module from NPM, the largest chunk of the total payload is from images in the test directory (around 7.5MB of a total of 13.6MB). So ignoring this directory will make the payload less than half the size it currently is.
Would you be okay with merging this in?