### PR TITLE
[New Feature] Blit Advanced

### DIFF
--- a/index.js
+++ b/index.js
@@ -709,8 +709,8 @@ Jimp.prototype.blit = function (src, x, y, cb) {
  * @param src the source Jimp instance
  * @param x the x position to blit the image
  * @param y the y position to blit the image
- * @param srcx the x position to blit the image
- * @param srcy the y position to blit the image
+ * @param srcx the x position in the source image
+ * @param srcy the y position in the source image
  * @param srcw the width size of the source image
  * @param srch the height size of the source image
  * @param (optional) cb a callback for when complete

--- a/index.js
+++ b/index.js
@@ -83,7 +83,7 @@ function Jimp() {
         var w = arguments[0];
         var h = arguments[1];
         var cb = arguments[2];
-        
+
         if ("number" == typeof arguments[2]) {
             this._background = arguments[2];
             var cb = arguments[3];
@@ -136,7 +136,7 @@ function Jimp() {
         // read from a path
         var path = arguments[0];
         var cb = arguments[1];
-        
+
         if ("undefined" == typeof cb) cb = noop;
         if ("function" != typeof cb)
             return throwError.call(this, "cb must be a function", cb);
@@ -311,9 +311,9 @@ Jimp.rgbaToInt = function(r, g, b, a, cb){
         return throwError.call(this, "b must be between 0 and 255", cb);
     if (a < 0 || a > 255)
         return throwError.call(this, "a must be between 0 and 255", cb);
-    
+
     var i = (r * Math.pow(256, 3)) + (g * Math.pow(256, 2)) + (b *  Math.pow(256, 1)) + (a * Math.pow(256, 0));
-    
+
     if (isNodePattern(cb)) return cb.call(this, null, i);
     else return i;
 }
@@ -327,13 +327,13 @@ Jimp.rgbaToInt = function(r, g, b, a, cb){
 Jimp.intToRGBA = function(i, cb){
     if ("number" != typeof i)
         return throwError.call(this, "i must be a number", cb);
-    
+
     var rgba = {}
     rgba.r = Math.floor(i / Math.pow(256, 3));
     rgba.g = Math.floor((i - (rgba.r * Math.pow(256, 3))) / Math.pow(256, 2));
     rgba.b = Math.floor((i - (rgba.r * Math.pow(256, 3)) - (rgba.g * Math.pow(256, 2))) / Math.pow(256, 1));
     rgba.a = Math.floor((i - (rgba.r * Math.pow(256, 3)) - (rgba.g * Math.pow(256, 2)) - (rgba.b * Math.pow(256, 1))) / Math.pow(256, 0));
-    
+
     if (isNodePattern(cb)) return cb.call(this, null, rgba);
     else return rgba;
 }
@@ -363,7 +363,7 @@ Jimp.diff = function (img1, img2, threshold) {
         return throwError.call(this, "img1 and img2 must be an Jimp images");
     if (img1.bitmap.width != img2.bitmap.width || img1.bitmap.height != img2.bitmap.height)
         return throwError.call(this, "img1 and img2 must be the same width and height");
-    
+
     threshold = threshold || 0.1;
     if ("number" != typeof threshold || threshold < 0 || threshold > 1)
         return throwError.call(this, "threshold must be a number between 0 and 1");
@@ -378,7 +378,7 @@ Jimp.diff = function (img1, img2, threshold) {
         diff.bitmap.height,
         {threshold: threshold}
     );
-    
+
     return {
         percent: numDiffPixels / (diff.bitmap.width * diff.bitmap.height),
         image: diff
@@ -594,10 +594,10 @@ Jimp.prototype.getPixelColor = Jimp.prototype.getPixelColour = function (x, y, c
     // round input
     x = Math.round(x);
     y = Math.round(y);
-    
+
     var idx = this.getPixelIndex(x, y);
     var hex = this.bitmap.data.readUInt32BE(idx);
-    
+
     if (isNodePattern(cb)) return cb.call(this, null, hex);
     else return hex;
 };
@@ -616,10 +616,10 @@ Jimp.prototype.setPixelColor = Jimp.prototype.setPixelColour = function (hex, x,
     // round input
     x = Math.round(x);
     y = Math.round(y);
-    
+
     var idx = this.getPixelIndex(x, y);
     this.bitmap.data.writeUInt32BE(hex, idx, true);
-    
+
     if (isNodePattern(cb)) return cb.call(this, null, this);
     else return this;
 };
@@ -705,6 +705,43 @@ Jimp.prototype.blit = function (src, x, y, cb) {
 };
 
 /**
+ * Blits a source image on to this image and accept source parameters
+ * @param src the source Jimp instance
+ * @param x the x position to blit the image
+ * @param y the y position to blit the image
+ * @param srcx the x position to blit the image
+ * @param srcy the y position to blit the image
+ * @param srcw the width size of the source image
+ * @param srch the height size of the source image
+ * @param (optional) cb a callback for when complete
+ * @returns this for chaining of methods
+*/
+Jimp.prototype.blitAdv = function (src, x, y, srcx, srcy, srcw, srch, cb) {
+	if ("object" != typeof src || src.constructor != Jimp)
+		return throwError.call(this, "The source must be a Jimp image", cb);
+	if ("number" != typeof x || "number" != typeof y)
+		return throwError.call(this, "x and y must be numbers", cb);
+
+	// round input
+	x = Math.round(x);
+	y = Math.round(y);
+
+	var that = this;
+
+	src.scan(0, 0, srcw ? srcw : src.bitmap.width, srch ? srch : src.bitmap.height, function(sx, sy, idx) {
+		var dstIdx = that.getPixelIndex(x+sx, y+sy);
+		var ix = that.getPixelIndex(srcx ? srcx+sx : sx, srcy ? srcy+sy : sy);
+		that.bitmap.data[dstIdx] = this.bitmap.data[ix];
+		that.bitmap.data[dstIdx+1] = this.bitmap.data[ix+1];
+		that.bitmap.data[dstIdx+2] = this.bitmap.data[ix+2];
+		that.bitmap.data[dstIdx+3] = this.bitmap.data[ix+3];
+	});
+
+	if (isNodePattern(cb)) return cb.call(this, null, this);
+	else return this;
+};
+
+/**
  * Masks a source image on to this image using average pixel colour. A completely black pixel on the mask will turn a pixel in the image completely transparent.
  * @param src the source Jimp instance
  * @param x the x position to blit the image
@@ -755,27 +792,27 @@ Jimp.prototype.composite = function (src, x, y, cb) {
     src.scan(0, 0, src.bitmap.width, src.bitmap.height, function(sx, sy, idx) {
         // http://stackoverflow.com/questions/7438263/alpha-compositing-algorithm-blend-modes
         var dstIdx = that.getPixelIndex(x+sx, y+sy);
-        
+
         var fg = {
             r: this.bitmap.data[idx + 0] / 255,
             g: this.bitmap.data[idx + 1] / 255,
             b: this.bitmap.data[idx + 2] / 255,
             a: this.bitmap.data[idx + 3] / 255
         }
-        
+
         var bg = {
             r: that.bitmap.data[dstIdx + 0] / 255,
             g: that.bitmap.data[dstIdx + 1] / 255,
             b: that.bitmap.data[dstIdx + 2] / 255,
             a: that.bitmap.data[dstIdx + 3] / 255
         }
-        
+
         var a = bg.a + fg.a - bg.a * fg.a;
-        
+
         var r = ((fg.r * fg.a) + (bg.r * bg.a) * (1 - fg.a)) / a;
         var g = ((fg.g * fg.a) + (bg.g * bg.a) * (1 - fg.a)) / a;
         var b = ((fg.b * fg.a) + (bg.b * bg.a) * (1 - fg.a)) / a;
-        
+
         that.bitmap.data[dstIdx + 0] = Jimp.limit255(r * 255);
         that.bitmap.data[dstIdx + 1] = Jimp.limit255(g * 255);
         that.bitmap.data[dstIdx + 2] = Jimp.limit255(b * 255);
@@ -1199,7 +1236,7 @@ Jimp.prototype.fade = function (f, cb) {
 
     // this method is an alternative to opacity (which may be deprecated)
     this.opacity(1 - f);
-    
+
     if (isNodePattern(cb)) return cb.call(this, null, this);
     else return this;
 };
@@ -1228,13 +1265,13 @@ Jimp.prototype.opaque = function (cb) {
 Jimp.prototype.resize = function (w, h, cb) {
     if ("number" != typeof w || "number" != typeof h)
         return throwError.call(this, "w and h must be numbers", cb);
-    
+
     if (w == Jimp.AUTO && h == Jimp.AUTO)
         return throwError.call(this, "w and h cannot both the set to auto", cb);
 
     if (w == Jimp.AUTO) w = this.bitmap.width * (h / this.bitmap.height);
     if (h == Jimp.AUTO) h = this.bitmap.height * (w / this.bitmap.width);
-    
+
     // round inputs
     w = Math.round(w);
     h = Math.round(h);
@@ -1266,7 +1303,7 @@ Jimp.prototype.cover = function (w, h, cb) {
         w/this.bitmap.width : h/this.bitmap.height;
     this.scale(f);
     this.crop(this.bitmap.width / 2 - w / 2, this.bitmap.height / 2 - h / 2, w, h);
-    
+
     if (isNodePattern(cb)) return cb.call(this, null, this);
     else return this;
 };
@@ -1285,13 +1322,13 @@ Jimp.prototype.contain = function (w, h, cb) {
     var f = (w/h > this.bitmap.width/this.bitmap.height) ?
         h/this.bitmap.height : w/this.bitmap.width;
     var c = this.clone().scale(f);
-    
+
     this.resize(w, h);
     this.scan(0, 0, this.bitmap.width, this.bitmap.height, function (x, y, idx) {
         this.bitmap.data.writeUInt32BE(this._background, idx);
     });
     this.blit(c, this.bitmap.width / 2 - c.bitmap.width / 2, this.bitmap.height / 2 - c.bitmap.height / 2);
-    
+
     if (isNodePattern(cb)) return cb.call(this, null, this);
     else return this;
 };
@@ -1339,7 +1376,7 @@ function simpleRotate(deg) {
         }
 
         this.bitmap.data = new Buffer(dstBuffer);
-        
+
         var tmp = this.bitmap.width;
         this.bitmap.width = this.bitmap.height;
         this.bitmap.height = tmp;
@@ -1357,7 +1394,7 @@ function advancedRotate(deg, resize) {
     var rad = (deg % 360) * Math.PI / 180;
     var cosine = Math.cos(rad);
     var sine = Math.sin(rad);
-    
+
     var w, h; // the final width and height if resize == true
 
     if (resize == true) {
@@ -1371,15 +1408,15 @@ function advancedRotate(deg, resize) {
         this.scan(0, 0, this.bitmap.width, this.bitmap.height, function (x, y, idx) {
             this.bitmap.data.writeUInt32BE(this._background, idx);
         });
-        
+
         var max= Math.max(w,h,this.bitmap.width,this.bitmap.height)
         this.resize(max, max);
-        
+
         this.blit(c, this.bitmap.width / 2 - c.bitmap.width / 2, this.bitmap.height / 2 - c.bitmap.height / 2);
     }
 
     var dstBuffer = new Buffer(this.bitmap.data.length);
-    
+
     function createTranslationFunction(deltaX, deltaY) {
         return function(x, y) {
             return {
@@ -1391,7 +1428,7 @@ function advancedRotate(deg, resize) {
 
     var translate2Cartesian = createTranslationFunction(-(this.bitmap.width / 2), -(this.bitmap.height / 2));
     var translate2Screen = createTranslationFunction(this.bitmap.width / 2, this.bitmap.height / 2);
-    
+
     for (var y = 0; y < this.bitmap.height; y++) {
         for (var x = 0; x < this.bitmap.width; x++) {
             var cartesian = translate2Cartesian(x, this.bitmap.height - y);
@@ -1413,7 +1450,7 @@ function advancedRotate(deg, resize) {
         }
     }
     this.bitmap.data = dstBuffer;
-    
+
     if (resize == true) {
         // now crop the image to the final size
         var x = (this.bitmap.width / 2) - (w/2);
@@ -1443,16 +1480,16 @@ Jimp.prototype.rotate = function (deg, resize, cb) {
         cb = resize;
         resize = true;
     }
-    
+
     if ("number" != typeof deg)
         return throwError.call(this, "deg must be a number", cb);
-    
+
     if ("boolean" != typeof resize)
         return throwError.call(this, "resize must be a boolean", cb);
 
     if (deg % 90 == 0 && resize !== false) simpleRotate.call(this, deg, cb);
     else advancedRotate.call(this, deg, resize, cb);
-    
+
     if (isNodePattern(cb)) return cb.call(this, null, this);
     else return this;
 };
@@ -1481,10 +1518,10 @@ Jimp.prototype.getBuffer = function (mime, cb) {
               colorType: (this._rgba) ? 6 : 2,
               inputHasAlpha: true
             });
-            
+
             if (this._rgba) png.data = new Buffer(this.bitmap.data);
             else png.data = compositeBitmapOverBackground(this).data; // when PNG doesn't support alpha
-            
+
             StreamToBuffer(png.pack(), function (err, buffer) {
                 return cb.call(that, null, buffer);
             });


### PR DESCRIPTION
Hi, 

Hi had a problem and find this solution very optimizing for me... 
It changes an [obfuscate image script](https://github.com/webcaetano/image-scramble) to process an 400x400 pixels image from 40 seconds to 120ms.

The source code 

```javascript
Jimp.prototype.blitAdv = function (src, x, y, srcx, srcy, srcw, srch, cb) {
	if ("object" != typeof src || src.constructor != Jimp)
		return throwError.call(this, "The source must be a Jimp image", cb);
	if ("number" != typeof x || "number" != typeof y)
		return throwError.call(this, "x and y must be numbers", cb);

	// round input
	x = Math.round(x);
	y = Math.round(y);

	var that = this;

	src.scan(0, 0, srcw ? srcw : src.bitmap.width, srch ? srch : src.bitmap.height, function(sx, sy, idx) {
		var dstIdx = that.getPixelIndex(x+sx, y+sy);
		var ix = that.getPixelIndex(srcx ? srcx+sx : sx, srcy ? srcy+sy : sy);
		that.bitmap.data[dstIdx] = this.bitmap.data[ix];
		that.bitmap.data[dstIdx+1] = this.bitmap.data[ix+1];
		that.bitmap.data[dstIdx+2] = this.bitmap.data[ix+2];
		that.bitmap.data[dstIdx+3] = this.bitmap.data[ix+3];
	});

	if (isNodePattern(cb)) return cb.call(this, null, this);
	else return this;
};
```

It's basically a blit function with source parameters. 
Before this the closer solution is use jimp.crop and then paste using  jimp.blit
Now you can just use jimp.blitAdv , that works like ctx.drawImage canvas


Hope you guys like it.