### PR TITLE
`.contain` does more than expected

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ image.mask( src, x, y );       // masks the image with another Jimp image at x, 
 image.dither565();             // ordered dithering of the image and reduce color space to 16-bits (RGB565)
 image.cover( w, h );           // scale the image so that it fills the given width and height
 image.contain( w, h );         // scale the image to the largest size so that fits inside the given width and height
+image.container( w, h );       // like `.contain`, but new areas (filled by the background color) are added to the image that starts to cover the whole w×h container
 image.background( hex );       // set the default new pixel colour (e.g. 0xFFFFFFFF or 0x00000000) for by some operations (e.g. image.contain and image.rotate) and when writing formats that don't support alpha channels
 image.mirror( horz, vert );    // an alias for flip
 image.fade( f );               // an alternative to opacity, fades the image by a factor 0 - 1. 0 will haven no effect. 1 will turn the image

--- a/index.js
+++ b/index.js
@@ -1461,6 +1461,26 @@ Jimp.prototype.contain = function (w, h, cb) {
 
     var f = (w/h > this.bitmap.width/this.bitmap.height) ?
         h/this.bitmap.height : w/this.bitmap.width;
+    this.scale(f);
+    
+    if (isNodePattern(cb)) return cb.call(this, null, this);
+    else return this;
+};
+
+/**
+ * Scale the image to the largest size so that its width and height fits inside the given width and height.
+ * Add new (background-filled) areas so that the image starts to cover the whole w×h container.
+ * @param w the width to resize the image to
+ * @param h the height to resize the image to
+ * @param (optional) cb a callback for when complete
+ * @returns this for chaining of methods
+ */
+Jimp.prototype.container = function (w, h, cb) {
+    if ("number" != typeof w || "number" != typeof h)
+        return throwError.call(this, "w and h must be numbers", cb);
+
+    var f = (w/h > this.bitmap.width/this.bitmap.height) ?
+        h/this.bitmap.height : w/this.bitmap.width;
     var c = this.clone().scale(f);
     
     this.resize(w, h);


### PR DESCRIPTION
`README.md` [currently](https://github.com/oliver-moran/jimp/blob/2d3da35d0f4791b1c5a3fb12d0dc58a7e1ce456e/README.md#basic-usage) says the following:

```js
image.contain( w, h ); // scale the image to the largest size so that fits inside the given width and height
```

However, in reality not only the `.scale` is performed, but also [background-filled rectangles are added around that image](https://github.com/oliver-moran/jimp/blob/2d3da35d0f4791b1c5a3fb12d0dc58a7e1ce456e/index.js#L1466-L1470) so that the image starts to cover the entire w×h area.

This pull request tones down the behaviour of `.contain`, makes it more README-corresponding.

The old abilities of `.contain` are, however, stored in the new method `.container` and explained anew in the README.