### PR TITLE
Catch expressions of jpeg-js

### DIFF
--- a/index.js
+++ b/index.js
@@ -248,9 +248,13 @@ function parseBitmap(data, mime, cb) {
             break;
 
         case Jimp.MIME_JPEG:
-            this.bitmap = JPEG.decode(data);
-            exifRotate(this, data); // EXIF data
-            return cb.call(this, null, this);
+            try {
+                this.bitmap = JPEG.decode(data);
+                exifRotate(this, data); // EXIF data
+                return cb.call(this, null, this);
+            } catch(err) {
+                return cb.call(this, err, this);
+            }
 
         case Jimp.MIME_BMP:
             this.bitmap = BMP.decode(data);


### PR DESCRIPTION
Currently expressions thrown by jpeg-js are not catched and they simply break the script.
If a file is corrupted, jpeg-js will throw a message which could be forwarded to the callback function.