### PR TITLE
Fixes browser build on OSX

### DIFF
--- a/browser/browserify-build.sh
+++ b/browser/browserify-build.sh
@@ -17,7 +17,7 @@ babel tmp1.js -o tmp.js --presets es2015,stage-0
 # module.exports = decode = function(bmpData) { ...
 # For some reason, babeljs misses this "error" but IE can parse the code fine without strict mode.
 echo "Removing Strict Mode."
-sed "s/^\"use strict\";\|ret=Z_BUF_ERROR;//" tmp.js > tmp-nostrict.js
+sed -E "s/^\"use strict\";|ret=Z_BUF_ERROR;//" tmp.js > tmp-nostrict.js
 
 echo "Adding Web Worker wrapper functions..."
 cat tmp-nostrict.js src/jimp-wrapper.js > tmp.jimp.js


### PR DESCRIPTION
Obscure differences in syntax between BSD and GNU sed break the build on Macs. Specifically the "or" operator and associated flags.

http://unix.stackexchange.com/questions/145402/regex-alternation-or-operator-foobar-in-gnu-or-bsd-sed

With this change to the build script, the browser build has tested successfully on Linux Mint 17.3 and OSX 10.9.5. Previously, it worked for Mint but failed for OSX.

While building on OSX, I also noticed that the browserify build may not run automatically after "npm install". If you don't see the script output:

```
Browserifying browser/jimp.js...
Translating for ES5...
[BABEL] Note: The code generator has deoptimised the styling of "tmp1.js" as it exceeds the max of "100KB".
Removing Strict Mode.
Adding Web Worker wrapper functions...
Minifying browser/jimp.min.js...
Including the License and version number in the jimp.js and jimp.min.js
Cleaning up....
```

Make sure you run this to verify the build process:

```
npm run-script prepublish
```

This should not be necessary for users of the library, as the script does run before publishing, which should mean the browser files are updated periodically at the right time. I can't test this though!