### PR TITLE
Add useXHR static method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ node_modules
 /test/output/*.png
 /test/output/*.jpg
 /test/output/*.bmp
+/.settings/

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ image.dither565();             // ordered dithering of the image and reduce colo
 image.cover( w, h );           // scale the image so that it fills the given width and height
 image.contain( w, h );         // scale the image to the largest size so that fits inside the given width and height
 image.background( hex );       // set the default new pixel colour (e.g. 0xFFFFFFFF or 0x00000000) for by some operations (e.g. image.contain and image.rotate) and when writing formats that don't support alpha channels
+image.align( bits );           // sets the alignment mode for cover and contain, default is Jimp.HORIZONTAL_ALIGN_CENTER | Jimp.VERTICAL_ALIGN_MIDDLE
 image.mirror( horz, vert );    // an alias for flip
 image.fade( f );               // an alternative to opacity, fades the image by a factor 0 - 1. 0 will haven no effect. 1 will turn the image
 image.opaque();                // set the alpha channel on every pixel to fully opaque

--- a/index.js
+++ b/index.js
@@ -14,7 +14,39 @@ var EXIFParser = require("exif-parser");
 var ImagePHash = require("./phash.js");
 var BigNumber = require('bignumber.js');
 var URLRegEx = require("url-regex");
-if (process.env.ENVIRONMENT !== 'BROWSER') var Request = require('request').defaults({ encoding: null });
+
+if (process.env.ENVIRONMENT !== 'BROWSER') {
+    var Request = require('request').defaults({ encoding: null });
+    //If we run into electron renderer process, add a method to substitute the request module by xhr method
+    if (process.versions.hasOwnProperty('electron') && process.type === 'renderer') {
+        var RequestXHR = function (url,cb) {
+            var xhr = new XMLHttpRequest();
+            xhr.open( "GET", url, true );
+            xhr.responseType = "arraybuffer";
+            xhr.onload = function() {
+                if (xhr.status < 400) {
+                    try {
+                        var data = Buffer.from(this.response);
+                    } catch (e) {
+                        return cb("Response is not a buffer for url "+url)
+                    }
+                    cb(null, xhr, data);
+                }
+                else cb("HTTP Status " + xhr.status + " for url "+url);
+            };
+            xhr.onerror = function(e) {
+                cb(e);
+            };
+            xhr.send();
+        };
+
+        Jimp.useXHR = function (use) {
+            use = typeof use === 'undefined' ? true:use;
+            Request = use ? RequestXHR:require('request');
+            return Jimp;
+        }
+    }
+}
 
 // polyfill Promise for Node < 0.12
 var Promise = Promise || require('es6-promise').Promise;

--- a/index.js
+++ b/index.js
@@ -346,6 +346,16 @@ Jimp.PNG_FILTER_UP = 2;
 Jimp.PNG_FILTER_AVERAGE = 3;
 Jimp.PNG_FILTER_PAETH = 4;
 
+// Align modes for cover, contain, bit masks
+Jimp.HORIZONTAL_ALIGN_LEFT = 1;
+Jimp.HORIZONTAL_ALIGN_CENTER = 2;
+Jimp.HORIZONTAL_ALIGN_RIGHT = 4;
+
+Jimp.VERTICAL_ALIGN_TOP = 8;
+Jimp.VERTICAL_ALIGN_MIDDLE = 16;
+Jimp.VERTICAL_ALIGN_BOTTOM = 32;
+
+// Resize modes for imagejs
 Jimp.RESIZE_NEAREST_NEIGHBOR = 'nearestNeighbor';
 Jimp.RESIZE_BILINEAR = 'bilinearInterpolation';
 Jimp.RESIZE_BICUBIC = 'bicubicInterpolation';
@@ -492,6 +502,10 @@ Jimp.prototype._rgba = true;
 // Default colour to use for new pixels
 Jimp.prototype._background = 0x00000000;
 
+// Default align factors
+Jimp.prototype._align_h = 1;
+Jimp.prototype._align_v = 1;
+
 /**
  * Creates a new image that is a clone of this one.
  * @param cb (optional) A callback for when complete
@@ -589,6 +603,34 @@ Jimp.prototype.background = function (hex, cb) {
     if (isNodePattern(cb)) return cb.call(this, null, this);
     else return this;
 };
+
+
+/**
+ * Sets the alignment mode for cover and contain
+ * @param bits A bitmask for horizontal and vertical alignment
+ * @param (optional) cb a callback for when complete
+ * @returns this for chaining of methods
+ */
+Jimp.prototype.align = function (bits, cb) {
+    if ("number" != typeof bits)
+        return throwError.call(this, "bits must be a bit mask", cb);
+    if (bits < 1 || bits > 36)
+        return throwError.call(this, "bits must be a number 1 - 36", cb);
+    
+    var hbits = ((bits) & ((1<<(3))-1));
+    var vbits = bits >> 3;
+    
+    // check if more flags than one is in the bit sets
+    if(!(((hbits != 0) && !(hbits & (hbits - 1))) || ((vbits != 0) && !(vbits & (vbits - 1)))))
+        return throwError.call(this, "only use one flag per alignment direction", cb);
+    
+    this._align_h = (hbits >> 1); // 0, 1, 2
+    this._align_v = (vbits >> 1); // 0, 1, 2
+    
+    if (isNodePattern(cb)) return cb.call(this, null, this);
+    else return this;
+};
+
 
 /**
  * Scanes through a region of the bitmap, calling a function for each pixel.
@@ -1575,7 +1617,7 @@ Jimp.prototype.cover = function (w, h, cb) {
     var f = (w/h > this.bitmap.width/this.bitmap.height) ?
         w/this.bitmap.width : h/this.bitmap.height;
     this.scale(f);
-    this.crop(this.bitmap.width / 2 - w / 2, this.bitmap.height / 2 - h / 2, w, h);
+    this.crop(((this.bitmap.width - w) / 2) * this._align_h, ((this.bitmap.height - h) / 2) * this._align_v, w, h);
     
     if (isNodePattern(cb)) return cb.call(this, null, this);
     else return this;
@@ -1600,7 +1642,7 @@ Jimp.prototype.contain = function (w, h, cb) {
     this.scan(0, 0, this.bitmap.width, this.bitmap.height, function (x, y, idx) {
         this.bitmap.data.writeUInt32BE(this._background, idx);
     });
-    this.blit(c, this.bitmap.width / 2 - c.bitmap.width / 2, this.bitmap.height / 2 - c.bitmap.height / 2);
+    this.blit(c, ((this.bitmap.width - c.bitmap.width) / 2) * this._align_h, ((this.bitmap.height - c.bitmap.height) / 2) * this._align_v);
     
     if (isNodePattern(cb)) return cb.call(this, null, this);
     else return this;


### PR DESCRIPTION
Add useXHR static method when executing in atom-electron renderer process. 

when we do Jimp.useXHR(true) It replace Request module by the XMLHttpRequest function of the browser to make http request for reading an image via url.

This can be usefull when the electron application is running on a network connected to the internet behind a proxy server. Because the browser is aware of the system proxy configuration and node isn't.

If you think this is an interesting feature, i can add a note in the readme before you merge.