### PR TITLE
Slighly less ugly build paths

### DIFF
--- a/browser/browserify-build.sh
+++ b/browser/browserify-build.sh
@@ -23,7 +23,7 @@ echo "Adding Web Worker wrapper functions..."
 cat tmp-nostrict.js src/jimp-wrapper.js > tmp.jimp.js
 echo "Minifying browser/jimp.min.js..."
 # uglifyjs tmp.jimp.js --compress warnings=false --mangle -o tmp.jimp.min.js
-"$PWD/../node_modules/uglify-js/bin/uglifyjs" tmp.jimp.js --compress warnings=false --mangle -o tmp.jimp.min.js
+npm run-script minify-jimp
 
 
 echo "Including the License and version number in the jimp.js and jimp.min.js"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "./test/tests.sh",
-    "prepublish": "./browser/browserify-build.sh"
+    "prepublish": "./browser/browserify-build.sh",
+    "minify-jimp": "uglifyjs browser/tmp.jimp.js --compress warnings=false --mangle -o browser/tmp.jimp.min.js"
   },
   "keywords": [
     "image",


### PR DESCRIPTION
Here's one modest improvement to the elegance.... npm is able to pick out the local copy of uglify, but apparently only if it's run through a script defined in package.json. Still not amazing.... thoughts?

https://lostechies.com/derickbailey/2012/04/24/executing-a-project-specific-nodenpm-package-a-la-bundle-exec/