### PR TITLE
Don't overwrite Promise if it already exists in the global scope

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ var URLRegEx = require("url-regex");
 if (process.env.ENVIRONMENT !== 'BROWSER') var Request = require('request').defaults({ encoding: null });
 
 // polyfill Promise for Node < 0.12
-var Promise = Promise || require('es6-promise').Promise;
+var Promise = global.Promise || require('es6-promise').Promise;
 
 // logging methods
 


### PR DESCRIPTION
Fixed the issue discussed here : https://github.com/oliver-moran/jimp/pull/113

Currently, the `Promise` object is always replaced by the `es6-promise` Promise implementation.
This PR fixes the issue (we need to explicitly use the [global](https://nodejs.org/api/globals.html#globals_global) node object).

> I don't understand why it the Promise variable "escaped" from its closure and overwrote the other promise.

`es6-promise` automatically polyfill some Promise implementations ([bluebird](https://github.com/petkaantonov/bluebird) for example).
See here for more details : https://github.com/stefanpenner/es6-promise/issues/163
