### PR TITLE
Define window

### DIFF
--- a/browser/browserify-build.sh
+++ b/browser/browserify-build.sh
@@ -37,8 +37,8 @@ cat ../LICENSE;
 echo "*/";
 echo ""; } > tmp.web_license.txt
 
-cat tmp.web_license.txt tmp.jimp.js > lib/jimp.js
-cat tmp.web_license.txt tmp.jimp.min.js > lib/jimp.min.js
+(cat tmp.web_license.txt ; echo "var window = window || self;" ; cat tmp.jimp.js; ) > lib/jimp.js
+(cat tmp.web_license.txt ; echo "var window = window || self;" ; cat tmp.jimp.min.js; ) > lib/jimp.min.js
 
 echo "Cleaning up...."
 rm tmp*

--- a/index.js
+++ b/index.js
@@ -1166,7 +1166,7 @@ function histogram() {
         b: new Array(256).fill(0)
     };
 
-    this.scan(0, 0, this.bitmap.width, this.bitmap.height, (x, y, index) => {
+    this.scan(0, 0, this.bitmap.width, this.bitmap.height, function(x, y, index){
         histogram.r[this.bitmap.data[index+0]]++;
         histogram.g[this.bitmap.data[index+1]]++;
         histogram.b[this.bitmap.data[index+2]]++;


### PR DESCRIPTION
Fixes a couple new issues with the browserify build:
- Choking on ES6 syntax in index.js (not sure why?)
- window is not defined error is thrown when running as a web worker (where ```self``` is the global variable)

See https://github.com/oliver-moran/jimp/issues/75