### PR TITLE
Change to new version of pngjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jimp",
-  "version": "0.2.23",
+  "version": "0.2.24",
   "description": "An image processing library written entirely in JavaScript (i.e. zero external or native dependencies).",
   "main": "index.js",
   "scripts": {
@@ -32,7 +32,7 @@
     "load-bmfont": "^1.2.3",
     "mime": "^1.3.4",
     "pixelmatch": "^4.0.0",
-    "pngjs": "2.2.0",
+    "pngjs": "^2.3.1",
     "read-chunk": "^1.0.1",
     "request": "^2.65.0",
     "stream-to-buffer": "^0.1.0",


### PR DESCRIPTION
They removed the `node-zlib-backport` dependency yesterday:
https://github.com/lukeapage/pngjs/commit/b914ab4d80add0844cfaec663a9f4f7cbaaca860

It should be possible to depend on the latest version again.