### PR TITLE
add xhr method for electron

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ var Path = require("path");
 if (process.env.ENVIRONMENT !== 'BROWSER') {
     var Request = require('request').defaults({ encoding: null });
     //If we run into electron renderer process, add a method to substitute the request module by xhr method
-    if (process.versions.hasOwnProperty('electron') && process.type === 'renderer') {
+    if (process.versions.hasOwnProperty('electron') && process.type === 'renderer' && typeof XMLHttpRequest === "function") {
         var RequestXHR = function (url,cb) {
             var xhr = new XMLHttpRequest();
             xhr.open( "GET", url, true );


### PR DESCRIPTION
Add useXHR static method when executing in atom-electron renderer process.

when we do Jimp.useXHR(true) It replace Request module by the XMLHttpRequest function of the browser to make http request for reading an image via url.

This can be usefull when the electron application is running on a network connected to the internet behind a proxy server. Because the browser is aware of the system proxy configuration and node isn't.

If you think this is an interesting feature, i can add a note in the readme before you merge.Add useXHR static method when executing in atom-electron renderer process.

when we do Jimp.useXHR(true) It replace Request module by the XMLHttpRequest function of the browser to make http request for reading an image via url.

This can be usefull when the electron application is running on a network connected to the internet behind a proxy server. Because the browser is aware of the system proxy configuration and node isn't.

If you think this is an interesting feature, i can add a note in the readme before you merge.

Sorry for the previous PRs my Git fork was messed up