### PR TITLE
Ignore color information of completely transparent pixels when resizing images

### DIFF
--- a/resize.js
+++ b/resize.js
@@ -67,7 +67,7 @@ Resize.prototype._resizeWidthInterpolatedRGBChannels = function (buffer, fourthC
     var secondWeight = 0;
     var outputBuffer = this.widthBuffer;
     //Handle for only one interpolation input being valid for start calculation:
-    for (var targetPosition = 0; weight < 1 / channelsNum; targetPosition += channelsNum, weight += ratioWeight) {
+    for (var targetPosition = 0; weight < 1 / 3; targetPosition += channelsNum, weight += ratioWeight) {
         for (finalOffset = targetPosition, pixelOffset = 0; finalOffset < this.widthPassResultSize; pixelOffset += this.originalWidthMultipliedByChannels, finalOffset += this.targetWidthMultipliedByChannels) {
             outputBuffer[finalOffset] = buffer[pixelOffset];
             outputBuffer[finalOffset + 1] = buffer[pixelOffset + 1];
@@ -86,9 +86,9 @@ Resize.prototype._resizeWidthInterpolatedRGBChannels = function (buffer, fourthC
         for (finalOffset = targetPosition, pixelOffset = Math.floor(weight) * channelsNum; finalOffset < this.widthPassResultSize; pixelOffset += this.originalWidthMultipliedByChannels, finalOffset += this.targetWidthMultipliedByChannels) {
             outputBuffer[finalOffset] = (buffer[pixelOffset] * firstWeight) + (buffer[pixelOffset + channelsNum] * secondWeight);
             outputBuffer[finalOffset + 1] = (buffer[pixelOffset + 1] * firstWeight) + (buffer[pixelOffset + channelsNum + 1] * secondWeight);
-            outputBuffer[finalOffset + 2] = (buffer[pixelOffset + 2] * firstWeight) + (buffer[pixelOffset + channelsNum + 1] * secondWeight);
+            outputBuffer[finalOffset + 2] = (buffer[pixelOffset + 2] * firstWeight) + (buffer[pixelOffset + channelsNum + 2] * secondWeight);
             if (!fourthChannel) continue;
-            outputBuffer[finalOffset + 3] = (buffer[pixelOffset + 3] * firstWeight) + (buffer[pixelOffset + channelsNum + 1] * secondWeight);
+            outputBuffer[finalOffset + 3] = (buffer[pixelOffset + 3] * firstWeight) + (buffer[pixelOffset + channelsNum + 3] * secondWeight);
         }
     }
     //Handle for only one interpolation input being valid for end calculation:
@@ -121,9 +121,9 @@ Resize.prototype._resizeWidthRGBChannels = function (buffer, fourthChannel) {
     var outputBuffer = this.widthBuffer;
     var trustworthyColorsCount = this.outputWidthWorkBenchOpaquePixelsCount;
     var multiplier = 1;
-    var r = 0; 
-    var g = 0; 
-    var b = 0; 
+    var r = 0;
+    var g = 0;
+    var b = 0;
     var a = 0;
     do {
         for (line = 0; line < this.originalHeightMultipliedByChannels;) {

--- a/resize2.js
+++ b/resize2.js
@@ -201,22 +201,29 @@ module.exports = {
                     var g = 0;
                     var b = 0;
                     var a = 0;
+                    var realColors = 0;
                     for (var y = 0; y < hM; y++) {
                         var yPos = i * hM + y;
                         for (var x = 0; x < wM; x++) {
                             var xPos = j * wM + x;
                             var xyPos = (yPos * wDst2 + xPos) * 4;
-                            r += buf2[xyPos];
-                            g += buf2[xyPos+1];
-                            b += buf2[xyPos+2];
-                            a += buf2[xyPos+3];
+                            var pixelAplha = buf2[xyPos+3];
+
+                            if (pixelAplha) {
+                                r += buf2[xyPos];
+                                g += buf2[xyPos+1];
+                                b += buf2[xyPos+2];
+                                realColors++;
+                            }
+
+                            a += pixelAplha;
                         }
                     }
                     
                     var pos = (i*wDst + j) * 4;
-                    bufDst[pos]   = Math.round(r / m);
-                    bufDst[pos+1] = Math.round(g / m);
-                    bufDst[pos+2] = Math.round(b / m);
+                    bufDst[pos]   = realColors ? Math.round(r / realColors) : 0;
+                    bufDst[pos+1] = realColors ? Math.round(g / realColors) : 0;
+                    bufDst[pos+2] = realColors ? Math.round(b / realColors) : 0;
                     bufDst[pos+3] = Math.round(a / m);
                 }
             }


### PR DESCRIPTION
Fixes artifact reported in haydenbleasel/favicons#123

Black faint on the edges of opaque areas appears because color information of completely transparent pixels is taken into account during calculation of average color, but these pixels could be of any color. Completely transparent black completely transparent red looks identicall, so it's somewhat a common practice to replace RGB values with 0 or 255 for series of completely transparent pixels. Many encoders do this, (probably) to allow for a better compression. 

Two images below illustrate what transparent areas sometimes look like if we make every pixel opaque.

<img src="http://i.imgur.com/PasQv5r.png" width="534" height="270">

This PR changes both submodules responsible for image resizing in the way that only color data of visible pixels used in average color calculation. Also ~~fixed incorrect channels value in `Resize.prototype.resizeWidthInterpolatedRGBA` method (Iwasawafag/jimp@65158a9) and~~ reduced amount of dupplicated code in `/resize.js`

And here's a comparison table.  6 images, every transparent pixel of which was painted in black, were scaled down from ~1000x1000 to 200x200 px using every resampling method supported. Then results from before and after patch were glued together for every image. The difference is pretty noticeable

|          | Resized to 200x200. Before/After (click to enlarge) |
|----------|-----------------------------------------------------|
| default  | <img width="170" src="http://i.imgur.com/GkfLLbi.png"> ~ <img width="170" src="http://i.imgur.com/UjmEnPb.png"> ~ <img width="170" src="http://i.imgur.com/tTDlSWo.png"> <img width="170" src="http://i.imgur.com/2c0MIVL.png"> ~ <img width="170" src="http://i.imgur.com/o6N02Fc.png"> ~ <img width="170" src="http://i.imgur.com/Cpk0qPa.png"> |
| bezier   | <img width="170" src="http://i.imgur.com/n8jV3iE.png"> ~ <img width="170" src="http://i.imgur.com/OkVGXW8.png"> ~ <img width="170" src="http://i.imgur.com/pDVVVxI.png"> <img width="170" src="http://i.imgur.com/Ztj3Npi.png"> ~ <img width="170" src="http://i.imgur.com/U1DtUmD.png"> ~ <img width="170" src="http://i.imgur.com/R2TuqtI.png"> |
| bicubic  | <img width="170" src="http://i.imgur.com/iHrnztU.png"> ~ <img width="170" src="http://i.imgur.com/UbWilwv.png"> ~ <img width="170" src="http://i.imgur.com/SVvqTQB.png"> <img width="170" src="http://i.imgur.com/6CVrswp.png"> ~ <img width="170" src="http://i.imgur.com/PnABISw.png"> ~ <img width="170" src="http://i.imgur.com/H5WgmCo.png"> |
| bilinear | <img width="170" src="http://i.imgur.com/gzWnSFN.png"> ~ <img width="170" src="http://i.imgur.com/oqNovDx.png"> ~ <img width="170" src="http://i.imgur.com/kQI2muT.png"> <img width="170" src="http://i.imgur.com/xuN1Wof.png"> ~ <img width="170" src="http://i.imgur.com/lLA6COU.png"> ~ <img width="170" src="http://i.imgur.com/YVqMAbD.png"> |
| hermite  | <img width="170" src="http://i.imgur.com/2YuiXyS.png"> ~ <img width="170" src="http://i.imgur.com/vmHZBrR.png"> ~ <img width="170" src="http://i.imgur.com/RHuKdiE.png"> <img width="170" src="http://i.imgur.com/Ax8sJHo.png"> ~ <img width="170" src="http://i.imgur.com/w18v3ip.png"> ~ <img width="170" src="http://i.imgur.com/GmHNlgL.png"> |
| nearest  | <img width="170" src="http://i.imgur.com/nU4Frz1.png"> ~ <img width="170" src="http://i.imgur.com/NNqkI1c.png"> ~ <img width="170" src="http://i.imgur.com/Z0yOzAu.png"> <img width="170" src="http://i.imgur.com/tYdrN21.png"> ~ <img width="170" src="http://i.imgur.com/r1JWq3C.png"> ~ <img width="170" src="http://i.imgur.com/K7GHVt2.png"> |

Here's list of images from the table above in their original size:

- [Check mark](http://i.imgur.com/l93ZrVT.png)
- [CP logo](http://i.imgur.com/OaEaqA4.png)
- [Green cross thing](http://i.imgur.com/Xp6pIIu.png)
- [Cross thing with gradient fill](http://i.imgur.com/0TwxXs1.png)
- [White cross thingy](http://i.imgur.com/y1T1DTw.png)
- [Red cross thingy](http://i.imgur.com/Ss68BIk.png)