### PR TITLE
fix: fixes bmp-js dependency error

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "license": "MIT",
   "dependencies": {
     "bignumber.js": "^2.1.0",
-    "bmp-js": "0.0.1",
+    "bmp-js": "0.0.2",
     "es6-promise": "^3.0.2",
     "exif-parser": "^0.1.9",
     "file-type": "^3.1.0",


### PR DESCRIPTION
fixes:

```
module.exports = encode = function(imgData, quality) {
                        ^
ReferenceError: encode is not defined
```

https://github.com/shaozilee/bmp-js/commit/a93b7b4d1afeeb2a52c3bb96969e158d6403a142