### PR TITLE
Use .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,7 +8,7 @@ indent_style = space
 indent_size = 4
 end_of_line = lf
 trim_trailing_whitespace = false
-insert_final_newline = false
+insert_final_newline = true
 
 [package.json]
 indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# See http://editorconfig.org/ for valid options and editor plugins.
+
+# Prevents EditorConfig from searching higher in the tree
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+trim_trailing_whitespace = false
+insert_final_newline = false
+
+[package.json]
+indent_size = 2


### PR DESCRIPTION
Adding a [EditorConfig](http://editorconfig.org/) file prevents editors from preforming bulk reformatting to match a different code style, as seen in f2842a7a8e6d407b05dc16e406f24ebba8f19040 on my fork (over 3k lines accidentally changed)

I've set both `trim_trailing_whitespace` to false, and `insert_final_newline` to true, as that's what the source seems to be using.  Alternatively, if you prefer not having trailing whitespace, you could take this opportunity to make the bulk change, and let EditorConfig enforce it for future changes.