### PR TITLE
Performance improvements

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,6 +16,8 @@ var BigNumber = require('bignumber.js');
 var URLRegEx = require("url-regex");
 var BMFont = require("load-bmfont");
 var Path = require("path");
+var Buffer = require("safe-buffer").Buffer;
+var isBuffer = require("is-buffer");
 
 if (process.env.ENVIRONMENT !== "BROWSER") {
     //If we run into electron renderer process, use XHR method instead of Request node module
@@ -126,7 +128,7 @@ function Jimp() {
             return throwError.call(this, "cb must be a function", cb);
 
         this.bitmap = {
-            data: new Buffer(w * h * 4),
+            data: Buffer.allocUnsafe(w * h * 4),
             width: w,
             height: h
         };
@@ -145,14 +147,8 @@ function Jimp() {
         if ("function" != typeof cb)
             return throwError.call(this, "cb must be a function", cb);
 
-        var bitmap = new Buffer(original.bitmap.data.length);
-        original.scan(0, 0, original.bitmap.width, original.bitmap.height, function (x, y, idx) {
-            var data = original.bitmap.data.readUInt32BE(idx, true);
-            bitmap.writeUInt32BE(data, idx, true);
-        });
-
         this.bitmap = {
-            data: bitmap,
+            data: Buffer.from(original.bitmap.data),
             width: original.bitmap.width,
             height: original.bitmap.height
         };
@@ -177,7 +173,7 @@ function Jimp() {
         var that = this;
         Request(url, function (err, response, data) {
             if (err) return throwError.call(that, err, cb);
-            if ("object" == typeof data && Buffer.isBuffer(data)) {
+            if ("object" == typeof data && isBuffer(data)) {
                 var mime = getMIMEFromBuffer(data);
                 if ("string" != typeof mime)
                     return throwError.call(that, "Could not find MIME for Buffer <" + url + "> (HTTP: " + response.statusCode + ")", cb);
@@ -206,7 +202,7 @@ function Jimp() {
         var mime = getMIMEFromBuffer(data);
         var cb = arguments[1];
 
-        if (!Buffer.isBuffer(data))
+        if (!isBuffer(data))
             return throwError.call(this, "data must be a Buffer", cb);
         if ("string" != typeof mime)
             return throwError.call(this, "mime must be a string", cb);
@@ -232,7 +228,7 @@ Jimp.read = function(src, cb) {
                 if (err) reject(err);
                 else resolve(image);
             }
-            if ("string" != typeof src && ("object" != typeof src || !Buffer.isBuffer(src)))
+            if ("string" != typeof src && ("object" != typeof src || !isBuffer(src)))
                 return throwError.call(this, "src must be a string or a Buffer", cb);
             var img = new Jimp(src, cb);
         }
@@ -282,7 +278,7 @@ function parseBitmap(data, mime, cb) {
             png.parse(data, function(err, data) {
                 if (err) return throwError.call(that, err, cb);
                 that.bitmap = {
-                    data: new Buffer(data.data),
+                    data: Buffer.from(data.data),
                     width: data.width,
                     height: data.height
                 };
@@ -835,7 +831,7 @@ Jimp.prototype.crop = function (x, y, w, h, cb) {
     w = Math.round(w);
     h = Math.round(h);
 
-    var bitmap = new Buffer(this.bitmap.data.length);
+    var bitmap = Buffer.allocUnsafe(this.bitmap.data.length);
     var offset = 0;
     this.scan(x, y, w, h, function (x, y, idx) {
         var data = this.bitmap.data.readUInt32BE(idx, true);
@@ -843,7 +839,7 @@ Jimp.prototype.crop = function (x, y, w, h, cb) {
         offset += 4;
     });
 
-    this.bitmap.data = new Buffer(bitmap);
+    this.bitmap.data = Buffer.from(bitmap);
     this.bitmap.width = w;
     this.bitmap.height = h;
 
@@ -1349,7 +1345,7 @@ Jimp.prototype.mirror = Jimp.prototype.flip = function (horizontal, vertical, cb
     if ("boolean" != typeof horizontal || "boolean" != typeof vertical)
         return throwError.call(this, "horizontal and vertical must be Booleans", cb);
 
-    var bitmap = new Buffer(this.bitmap.data.length);
+    var bitmap = Buffer.allocUnsafe(this.bitmap.data.length);
     this.scan(0, 0, this.bitmap.width, this.bitmap.height, function (x, y, idx) {
         var _x = (horizontal) ? (this.bitmap.width - 1 - x) : x;
         var _y = (vertical) ? (this.bitmap.height - 1 - y) : y;
@@ -1359,7 +1355,7 @@ Jimp.prototype.mirror = Jimp.prototype.flip = function (horizontal, vertical, cb
         bitmap.writeUInt32BE(data, _idx, true);
     });
 
-    this.bitmap.data = new Buffer(bitmap);
+    this.bitmap.data = Buffer.from(bitmap);
 
     if (isNodePattern(cb)) return cb.call(this, null, this);
     else return this;
@@ -1696,7 +1692,7 @@ Jimp.prototype.resize = function (w, h, mode, cb) {
 
     if ("function" == typeof Resize2[mode]) {
         var dst = {
-            data: new Buffer(w * h * 4),
+            data: Buffer.allocUnsafe(w * h * 4),
             width: w,
             height: h
         };
@@ -1705,7 +1701,7 @@ Jimp.prototype.resize = function (w, h, mode, cb) {
     } else {
         var that = this;
         var resize = new Resize(this.bitmap.width, this.bitmap.height, w, h, true, true, function (buffer) {
-            that.bitmap.data = new Buffer(buffer);
+            that.bitmap.data = Buffer.from(buffer);
             that.bitmap.width = w;
             that.bitmap.height = h;
         });
@@ -1875,7 +1871,7 @@ function simpleRotate(deg) {
 
     while (i > 0) {
         // https://github.com/ekulabuhov/jimp/commit/9a0c7cff88292d88c32a424b11256c76f1e20e46
-        var dstBuffer = new Buffer(this.bitmap.data.length);
+        var dstBuffer = Buffer.allocUnsafe(this.bitmap.data.length);
         var dstOffset = 0;
         for (var x = 0; x < this.bitmap.width; x++) {
             for (var y = this.bitmap.height - 1; y >= 0; y--) {
@@ -1886,7 +1882,7 @@ function simpleRotate(deg) {
             }
         }
 
-        this.bitmap.data = new Buffer(dstBuffer);
+        this.bitmap.data = Buffer.from(dstBuffer);
         
         var tmp = this.bitmap.width;
         this.bitmap.width = this.bitmap.height;
@@ -1927,7 +1923,7 @@ function advancedRotate(deg, mode) {
         this.blit(c, this.bitmap.width / 2 - c.bitmap.width / 2, this.bitmap.height / 2 - c.bitmap.height / 2);
     }
 
-    var dstBuffer = new Buffer(this.bitmap.data.length);
+    var dstBuffer = Buffer.allocUnsafe(this.bitmap.data.length);
     
     function createTranslationFunction(deltaX, deltaY) {
         return function(x, y) {
@@ -2036,7 +2032,7 @@ Jimp.prototype.getBuffer = function (mime, cb) {
               inputHasAlpha: true
             });
             
-            if (this._rgba) png.data = new Buffer(this.bitmap.data);
+            if (this._rgba) png.data = Buffer.from(this.bitmap.data);
             else png.data = compositeBitmapOverBackground(this).data; // when PNG doesn't support alpha
             
             StreamToBuffer(png.pack(), function (err, buffer) {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "es6-promise": "^3.0.2",
     "exif-parser": "^0.1.9",
     "file-type": "^3.1.0",
+    "is-buffer": "^1.1.4",
     "jpeg-js": "^0.2.0",
     "load-bmfont": "^1.2.3",
     "mime": "^1.3.4",
@@ -35,6 +36,7 @@
     "pngjs": "^3.0.0",
     "read-chunk": "^1.0.1",
     "request": "^2.65.0",
+    "safe-buffer": "^5.0.1",
     "stream-to-buffer": "^0.1.0",
     "tinycolor2": "^1.1.2",
     "url-regex": "^3.0.0"


### PR DESCRIPTION
Hello.

I noticed that some methods waste time by doing unnecessary work like [clonning newly created buffers](https://github.com/oliver-moran/jimp/blob/master/index.js#L1352-L1362) or [allocating buffers larger than needed](https://github.com/oliver-moran/jimp/blob/master/index.js#L838) and decided to fix that. So I changed that, added some shortcuts here and there and changed `simpleRotate` in a way so in doesnt have to iterate over every pixel more than once in for any angle supported.

Here are some numbers:

### `Jimp#rotate` (`simpleRotate`)

- Saves some time by not creating extra buffer. 
- Added special handling for 180 degree turn, rotation by 90/270 degrees always performed by the shortest route

```
// Rotate by 90 degrees
Jimp#rotate old x 230 ops/sec ±0.83% (189 runs sampled)
Jimp#rotate new x 257 ops/sec ±0.32% (196 runs sampled)

// Rotate by 180 degrees
Jimp#rotate old x 115 ops/sec ±0.48% (190 runs sampled)
Jimp#rotate new x 402 ops/sec ±0.17% (201 runs sampled)

// Rotate by 270 degrees
Jimp#rotate old x 77.28 ops/sec ±0.31% (176 runs sampled)
Jimp#rotate new x 253 ops/sec ±0.38% (196 runs sampled)
```

### `Jimp#flip`

- Saves some time by not creating extra buffer. 
- When flipping in both directions - uses simple rotation by 180 degree from above. 

```
// Flip horizontally
Jimp#rotate old x 31.34 ops/sec ±1.27% (169 runs sampled)
Jimp#rotate new x 92.31 ops/sec ±0.39% (181 runs sampled)

// Flip vertically
Jimp#rotate old x 31.10 ops/sec ±1.34% (168 runs sampled)
Jimp#rotate new x 102 ops/sec ±0.74% (186 runs sampled)

// Flip horizontally and vertically
Jimp#rotate old x 23.95 ops/sec ±1.11% (158 runs sampled)
Jimp#rotate new x 396 ops/sec ±0.49% (198 runs sampled)
```

### `Jimp#crop`

- Allocates buffer of correct length. 
- When possible - uses `Buffer#slice`, so cropped image would uses same memory as old buffer, just with different offset, 

(note: following numbers also include time of clonning test image in every run)

```
// Copy image and crop
Jimp#crop old x 252 ops/sec ±0.35% (193 runs sampled)
Jimp#crop new x 324 ops/sec ±0.76% (193 runs sampled)

// Copy image and crop without changing width
Jimp#crop old x 166 ops/sec ±0.63% (192 runs sampled)
Jimp#crop new x 1,199 ops/sec ±4.58% (179 runs sampled)
```