### PR TITLE
Fix a small rounding error in Nearest Neighbor algorithm

### DIFF
--- a/resize2.js
+++ b/resize2.js
@@ -37,8 +37,8 @@ module.exports = {
             for (let j = 0; j < wDst; j++) {
                 var posDst = (i * wDst + j) * 4;
 
-                var iSrc = Math.round(i * hSrc / hDst);
-                var jSrc = Math.round(j * wSrc / wDst);
+                var iSrc = Math.floor(i * hSrc / hDst);
+                var jSrc = Math.floor(j * wSrc / wDst);
                 var posSrc = (iSrc * wSrc + jSrc) * 4;
 
                 bufDst[posDst++] = bufSrc[posSrc++];


### PR DESCRIPTION
There seems to be a small error in the Nearest Neighbor algorithm for resizing images that produces unpleasant results for pixel-perfect images.

Below, I put a pixel-art image that I upscale by a factor of two. The first picture is the original pixel-art image, the second one is the upscaled version using the current algorithm, the third and last one is the upscaled version with the small modification I've made.

You can notice, for example, that the upper-right corner is not properly upscaled on the second screenshot.

![paintdotnet_2017-07-29_11-39-57](https://user-images.githubusercontent.com/9724878/28743787-ab8c0086-7452-11e7-80e9-8be0e9e60f87.png)

![twine_2017-07-29_11-36-18](https://user-images.githubusercontent.com/9724878/28743779-8e75dea4-7452-11e7-8b1d-7530abf2bd4a.png)
![twine_2017-07-29_11-38-58](https://user-images.githubusercontent.com/9724878/28743780-9101f4fa-7452-11e7-91fe-e410215dcb49.png)
