### PR TITLE
Correct getPixelColor doc

### DIFF
--- a/index.js
+++ b/index.js
@@ -882,7 +882,7 @@ Jimp.prototype.getPixelIndex = function (x, y, edgeHandling, cb) {
  * @param x the x coordinate
  * @param y the y coordinate
  * @param (optional) cb a callback for when complete
- * @returns the index of the pixel or -1 if not found
+ * @returns the color of the pixel
 */
 Jimp.prototype.getPixelColor = Jimp.prototype.getPixelColour = function (x, y, cb) {
     if (typeof x !== "number" || typeof y !== "number")


### PR DESCRIPTION
The @returns of getPixelColor is currently "the index of the pixel or -1 if not found" - probaly copied from getPixelIndex and forgot to change.