### PR TITLE
Rewrite the type declarations file

### DIFF
--- a/jimp.d.ts
+++ b/jimp.d.ts
@@ -4,6 +4,12 @@ declare namespace Jimp {
     type ColorActionName = 'mix' | 'tint' | 'shade' | 'xor' | 'red' | 'green' | 'blue' | 'hue';
     type ColorAction = { apply: ColorActionName, params: any };
 
+    type PrintableText = string | {
+        text: string;
+        alignmentX: number;
+        alignmentY: number;
+    };
+
     interface Bitmap {
         data: Buffer;
         width: number;
@@ -19,6 +25,61 @@ declare namespace Jimp {
         g: number;
         b: number;
         a: number;
+    }
+
+    interface FontChar {
+        id: number;
+        x: number;
+        y: number;
+        width: number;
+        height: number;
+        xoffset: number;
+        yoffset: number;
+        xadvance: number;
+        page: number;
+        chnl: number;
+    }
+
+
+    interface FontInfo {
+        face: string;
+        size: number;
+        bold: number;
+        italic: number;
+        charset: string;
+        unicode: number;
+        stretchH: number;
+        smooth: number;
+        aa: number;
+        padding: [number, number, number, number];
+        spacing: [number, number];
+    }
+
+    interface FontCommon {
+        lineHeight: number;
+        base: number;
+        scaleW: number;
+        scaleH: number;
+        pages: number;
+        packed: number;
+        alphaChnl: number;
+        redChnl: number;
+        greenChnl: number;
+        blueChnl: number;
+    }
+
+    interface Font {
+        chars: {
+            [char: string]: FontChar;
+        };
+        kernings: {
+            [firstString: string]: {
+                [secondString: string]: number;
+            };
+        };
+        pages: string[];
+        common: FontCommon;
+        info: FontInfo;
     }
 
     class Jimp {
@@ -467,69 +528,143 @@ declare namespace Jimp {
         autocrop(
             tolerance?: number,
             cropOnlyFrames?: boolean,
-            cb?: Jimp.ImageCallback
         ): this;
+        autocrop<T>(
+            tolerance: number | undefined | null,
+            cb: Jimp.ImageCallback<T>
+        ): T;
+        autocrop(
+            cropOnlyFrames: boolean | undefined | null,
+        ): this;
+        autocrop<T>(
+            cropOnlyFrames: boolean | undefined | null,
+            cb: Jimp.ImageCallback<T>
+        ): T;
+        autocrop<T>(
+            tolerance: number | undefined | null,
+            cropOnlyFrames: boolean | undefined | null,
+            cb: Jimp.ImageCallback<T>
+        ): T;
 
         // Text methods
         print(
-            font: any,
+            font: Font,
             x: number,
             y: number,
-            text: string,
-            maxWidth?: number | Jimp.ImageCallback,
-            maxHeight?: number | Jimp.ImageCallback,
-            cb?: Jimp.ImageCallback
+            text: PrintableText,
+            maxWidth?: number,
+            maxHeight?: number
         ): this;
+        print<T>(
+            font: Font,
+            x: number,
+            y: number,
+            text: PrintableText,
+            cb: Jimp.ImageCallback<T>
+        ): T;
+        print<T>(
+            font: Font,
+            x: number,
+            y: number,
+            text: PrintableText,
+            maxWidth: number | undefined | null,
+            cb: Jimp.ImageCallback<T>
+        ): T;
+        print<T>(
+            font: Font,
+            x: number,
+            y: number,
+            text: PrintableText,
+            maxWidth: number | undefined | null,
+            maxHeight: number | undefined | null,
+            cb: Jimp.ImageCallback<T>
+        ): T;
 
         // Effect methods
-        blur(r: number, cb?: Jimp.ImageCallback): this;
-        dither565(cb?: Jimp.ImageCallback): this;
-        dither16(cb?: Jimp.ImageCallback): this;
+        blur(r: number): this;
+        blur<T>(r: number, cb: Jimp.ImageCallback<T>): T;
+        dither565(): this;
+        dither565<T>(cb: Jimp.ImageCallback<T>): T;
+        dither16(): this;
+        dither16<T>(cb: Jimp.ImageCallback<T>): T;
         histogram(): { r: number[]; g: number[]; b: number[] };
-        normalize(cb?: Jimp.ImageCallback): this;
-        invert(cb?: Jimp.ImageCallback): this;
-        gaussian(r: number, cb?: Jimp.ImageCallback): this;
+        normalize(): this;
+        normalize<T>(cb: Jimp.ImageCallback<T>): T;
+        invert(): this;
+        invert<T>(cb: Jimp.ImageCallback<T>): T;
+        gaussian(r: number): this;
+        gaussian<T>(r: number, cb: Jimp.ImageCallback<T>): T;
         composite(
             src: Jimp,
             x: number,
-            y: number,
-            cb?: Jimp.ImageCallback
+            y: number
         ): this;
+        composite<T>(
+            src: Jimp,
+            x: number,
+            y: number,
+            cb: Jimp.ImageCallback<T>
+        ): T;
+        blit(
+            src: Jimp,
+            x: number,
+            y: number
+        ): this;
+        blit<T>(
+            src: Jimp,
+            x: number,
+            y: number,
+            cb: Jimp.ImageCallback<T>
+        ): T;
         blit(
             src: Jimp,
             x: number,
             y: number,
-            srcx?: number,
-            srcy?: number,
-            srcw?: number,
-            srch?: number,
-            cb?: Jimp.ImageCallback
+            srcx: number,
+            srcy: number,
+            srcw: number,
+            srch: number,
         ): this;
-        mask(src: Jimp, x: number, y: number, cb?: Jimp.ImageCallback): this;
+        blit<T>(
+            src: Jimp,
+            x: number,
+            y: number,
+            srcx: number,
+            srcy: number,
+            srcw: number,
+            srch: number,
+            cb: Jimp.ImageCallback<T>
+        ): T;
+        mask(src: Jimp, x: number, y: number): this;
+        mask<T>(src: Jimp, x: number, y: number, cb: Jimp.ImageCallback<T>): T;
 
         // Functions
-        static appendConstructorOption(
+        static appendConstructorOption<T>(
             name: string,
-            test: Function,
-            run: Function
+            test: (...args: T) => boolean,
+            run: (this: this, resolve: (jimp: Jimp) => any, reject: (reason: Error) => any, ...args: T) => any
         );
         static read(path: string): Promise<Jimp>;
         static read(image: Jimp): Promise<Jimp>;
         static read(data: Buffer): Promise<Jimp>;
-        static read(w: number, h: number): Promise<Jimp>;
         static read(w: number, h: number, background?: number): Promise<Jimp>;
         static create(path: string): Promise<Jimp>;
         static create(image: Jimp): Promise<Jimp>;
         static create(data: Buffer): Promise<Jimp>;
-        static create(w: number, h: number): Promise<Jimp>;
         static create(w: number, h: number, background?: number): Promise<Jimp>;
         static rgbaToInt(
             r: number,
             g: number,
             b: number,
             a: number,
-            cb?: GenericCallback<number>
         ): number;
+        static rgbaToInt<T>(
+            r: number,
+            g: number,
+            b: number,
+            a: number,
+            cb: GenericCallback<number, T, Jimp>
+        ): T;
         static intToRGBA(
             i: number,
             cb?: GenericCallback<Jimp.RGBA>
@@ -542,10 +677,15 @@ declare namespace Jimp {
         ): { percent: number; image: Jimp };
         static distance(img1: Jimp, img2: Jimp): number;
         static colorDiff(
-            rgba1: Jimp.RGB | Jimp.RGBA,
-            rgba2: Jimp.RGB | Jimp.RGBA
+            rgba1: Jimp.RGB,
+            rgba2: Jimp.RGB
         ): number;
-        static loadFont(file: string, cb?: Jimp.ImageCallback): Promise<any>;
+        static colorDiff(
+            rgba1: Jimp.RGBA,
+            rgba2: Jimp.RGBA
+        ): number;
+        static loadFont(file: string): Promise<Font>;
+        static loadFont(file: string, cb: Jimp.GenericCallback<Font, any, any>): Promise<never>;
     }
 }
 

--- a/jimp.d.ts
+++ b/jimp.d.ts
@@ -1,14 +1,28 @@
 declare namespace Jimp {
-    type GenericCallback<T, U = any, TThis = any> = (this: TThis, err: Error | null, value: T) => U;
+    type GenericCallback<T, U = any, TThis = any> = (
+        this: TThis,
+        err: Error | null,
+        value: T
+    ) => U;
     type ImageCallback<U = any> = GenericCallback<Jimp, U, Jimp>;
-    type ColorActionName = 'mix' | 'tint' | 'shade' | 'xor' | 'red' | 'green' | 'blue' | 'hue';
-    type ColorAction = { apply: ColorActionName, params: any };
+    type ColorActionName =
+        | 'mix'
+        | 'tint'
+        | 'shade'
+        | 'xor'
+        | 'red'
+        | 'green'
+        | 'blue'
+        | 'hue';
+    type ColorAction = { apply: ColorActionName; params: any };
 
-    type PrintableText = string | {
-        text: string;
-        alignmentX: number;
-        alignmentY: number;
-    };
+    type PrintableText =
+        | string
+        | {
+              text: string;
+              alignmentX: number;
+              alignmentY: number;
+          };
 
     interface Bitmap {
         data: Buffer;
@@ -39,7 +53,6 @@ declare namespace Jimp {
         page: number;
         chnl: number;
     }
-
 
     interface FontInfo {
         face: string;
@@ -83,7 +96,6 @@ declare namespace Jimp {
     }
 
     class Jimp {
-
         // Constants
         static AUTO: -1;
 
@@ -177,7 +189,10 @@ declare namespace Jimp {
         getBase64Async(mime: string): Promise<Jimp>;
         hash(base?: number): string;
         hash<T>(cb: GenericCallback<string, T, this>): T;
-        hash<T>(base: number | null | undefined, cb: GenericCallback<string, T, this>): T;
+        hash<T>(
+            base: number | null | undefined,
+            cb: GenericCallback<string, T, this>
+        ): T;
         getBuffer(mime: string, cb: GenericCallback<Buffer>): this;
         getBufferAsync(mime: string): Promise<Buffer>;
         getPixelIndex<T>(
@@ -185,51 +200,33 @@ declare namespace Jimp {
             y: number,
             cb: GenericCallback<number, T, this>
         ): T;
-        getPixelIndex(
-            x: number,
-            y: number,
-            edgeHandling?: string
-        ): number;
+        getPixelIndex(x: number, y: number, edgeHandling?: string): number;
         getPixelIndex<T>(
             x: number,
             y: number,
             edgeHandling: string,
             cb: GenericCallback<number, T, this>
         ): T;
-        getPixelColor(
-            x: number,
-            y: number,
-        ): number;
+        getPixelColor(x: number, y: number): number;
         getPixelColor<T>(
             x: number,
             y: number,
             cb: GenericCallback<number, T, this>
         ): T;
-        getPixelColour(
-            x: number,
-            y: number,
-        ): number;
+        getPixelColour(x: number, y: number): number;
         getPixelColour<T>(
             x: number,
             y: number,
             cb: GenericCallback<number, T, this>
         ): T;
-        setPixelColor(
-            hex: number,
-            x: number,
-            y: number,
-        ): this;
+        setPixelColor(hex: number, x: number, y: number): this;
         setPixelColor<T>(
             hex: number,
             x: number,
             y: number,
             cb: Jimp.ImageCallback<T>
         ): T;
-        setPixelColour(
-            hex: number,
-            x: number,
-            y: number,
-        ): this;
+        setPixelColour(hex: number, x: number, y: number): this;
         setPixelColour<T>(
             hex: number,
             x: number,
@@ -249,7 +246,7 @@ declare namespace Jimp {
             y: number,
             w: number,
             h: number,
-            f: (this: this, x: number, y: number, idx: number) => any,
+            f: (this: this, x: number, y: number, idx: number) => any
         ): this;
         scan<T>(
             x: number,
@@ -264,7 +261,7 @@ declare namespace Jimp {
             y: number,
             w: number,
             h: number,
-            f: (this: this, x: number, y: number, idx: number) => any,
+            f: (this: this, x: number, y: number, idx: number) => any
         ): this;
         scanQuiet<T>(
             x: number,
@@ -274,12 +271,7 @@ declare namespace Jimp {
             f: (this: this, x: number, y: number, idx: number) => any,
             cb: Jimp.ImageCallback<T>
         ): T;
-        crop(
-            x: number,
-            y: number,
-            w: number,
-            h: number,
-        ): this;
+        crop(x: number, y: number, w: number, h: number): this;
         crop<T>(
             x: number,
             y: number,
@@ -287,12 +279,7 @@ declare namespace Jimp {
             h: number,
             cb: Jimp.ImageCallback<T>
         ): T;
-        cropQuiet(
-            x: number,
-            y: number,
-            w: number,
-            h: number,
-        ): this;
+        cropQuiet(x: number, y: number, w: number, h: number): this;
         cropQuiet<T>(
             x: number,
             y: number,
@@ -318,17 +305,9 @@ declare namespace Jimp {
         sepia<T>(cb: Jimp.ImageCallback<T>): T;
         fade(f: number): this;
         fade<T>(f: number, cb: Jimp.ImageCallback<T>): T;
-        convolution(
-            kernel: number[][],
-        ): this;
-        convolution<T>(
-            kernel: number[][],
-            cb: Jimp.ImageCallback<T>
-        ): T;
-        convolution(
-            kernel: number[][],
-            edgeHandling: string
-        ): this;
+        convolution(kernel: number[][]): this;
+        convolution<T>(kernel: number[][], cb: Jimp.ImageCallback<T>): T;
+        convolution(kernel: number[][], edgeHandling: string): this;
         convolution<T>(
             kernel: number[][],
             edgeHandling: string,
@@ -336,16 +315,13 @@ declare namespace Jimp {
         ): T;
         opaque(): this;
         opaque<T>(cb: Jimp.ImageCallback<T>): T;
-        pixelate<T>(
-            size: number,
-            cb: Jimp.ImageCallback<T>
-        ): T;
+        pixelate<T>(size: number, cb: Jimp.ImageCallback<T>): T;
         pixelate(
             size: number,
             x: number,
             y: number,
             w: number,
-            h: number,
+            h: number
         ): this;
         pixelate<T>(
             size: number,
@@ -355,16 +331,13 @@ declare namespace Jimp {
             h: number,
             cb: Jimp.ImageCallback<T>
         ): T;
-        convolute<T>(
-            kernel: number[][],
-            cb: Jimp.ImageCallback<T>
-        ): T;
+        convolute<T>(kernel: number[][], cb: Jimp.ImageCallback<T>): T;
         convolute(
             kernel: number[][],
             x: number,
             y: number,
             w: number,
-            h: number,
+            h: number
         ): this;
         convolute<T>(
             kernel: number[][],
@@ -380,70 +353,41 @@ declare namespace Jimp {
         colour<T>(actions: ColorAction[], cb: Jimp.ImageCallback<T>): T;
 
         // Shape methods
-        rotate<T>(
-            deg: number,
-            cb: Jimp.ImageCallback<T>
-        ): T;
-        rotate(
-            deg: number,
-            mode?: number | boolean,
-        ): this;
+        rotate<T>(deg: number, cb: Jimp.ImageCallback<T>): T;
+        rotate(deg: number, mode?: number | boolean): this;
         rotate<T>(
             deg: number,
             mode: number | boolean | undefined | null,
             cb: Jimp.ImageCallback<T>
         ): T;
-        flip(
-            horizontal: boolean,
-            vertical: boolean
-        ): this;
+        flip(horizontal: boolean, vertical: boolean): this;
         flip<T>(
             horizontal: boolean,
             vertical: boolean,
             cb: Jimp.ImageCallback<T>
         ): T;
-        mirror(
-            horizontal: boolean,
-            vertical: boolean
-        ): this;
+        mirror(horizontal: boolean, vertical: boolean): this;
         mirror<T>(
             horizontal: boolean,
             vertical: boolean,
             cb: Jimp.ImageCallback<T>
         ): T;
-        resize<T>(
-            w: number,
-            h: number,
-            cb: Jimp.ImageCallback<T>
-        ): T;
-        resize(
-            w: number,
-            h: number,
-            mode?: string
-        ): this;
+        resize<T>(w: number, h: number, cb: Jimp.ImageCallback<T>): T;
+        resize(w: number, h: number, mode?: string): this;
         resize<T>(
             w: number,
             h: number,
             mode: string | undefined | null,
             cb: Jimp.ImageCallback<T>
         ): T;
-        cover<T>(
-            w: number,
-            h: number,
-            cb: Jimp.ImageCallback<T>
-        ): T;
+        cover<T>(w: number, h: number, cb: Jimp.ImageCallback<T>): T;
         cover<T>(
             w: number,
             h: number,
             alignBits: number | undefined | null,
             cb: Jimp.ImageCallback<T>
         ): T;
-        cover(
-            w: number,
-            h: number,
-            alignBits?: number,
-            mode?: string
-        ): this;
+        cover(w: number, h: number, alignBits?: number, mode?: string): this;
         cover<T>(
             w: number,
             h: number,
@@ -451,43 +395,23 @@ declare namespace Jimp {
             mode: string | undefined | null,
             cb: Jimp.ImageCallback<T>
         ): T;
-        contain(
-            w: number,
-            h: number
-        ): this;
-        contain<T>(
-            w: number,
-            h: number,
-            cb: Jimp.ImageCallback<T>
-        ): T;
-        contain(
-            w: number,
-            h: number,
-            mode: string
-        ): this;
+        contain(w: number, h: number): this;
+        contain<T>(w: number, h: number, cb: Jimp.ImageCallback<T>): T;
+        contain(w: number, h: number, mode: string): this;
         contain<T>(
             w: number,
             h: number,
             mode: string,
             cb: Jimp.ImageCallback<T>
         ): T;
-        contain(
-            w: number,
-            h: number,
-            alignBits: number
-        ): this;
+        contain(w: number, h: number, alignBits: number): this;
         contain<T>(
             w: number,
             h: number,
             alignBits: number,
             cb: Jimp.ImageCallback<T>
         ): T;
-        contain(
-            w: number,
-            h: number,
-            alignBits: number,
-            mode: string
-        ): this;
+        contain(w: number, h: number, alignBits: number, mode: string): this;
         contain<T>(
             w: number,
             h: number,
@@ -495,28 +419,15 @@ declare namespace Jimp {
             mode: string,
             cb: Jimp.ImageCallback<T>
         ): T;
-        scale<T>(
-            f: number,
-            cb: Jimp.ImageCallback<T>
-        ): T;
-        scale(
-            f: number,
-            mode?: string
-        ): this;
+        scale<T>(f: number, cb: Jimp.ImageCallback<T>): T;
+        scale(f: number, mode?: string): this;
         scale<T>(
             f: number,
             mode: string | undefined | null,
             cb: Jimp.ImageCallback<T>
         ): T;
-        scaleToFit<T>(
-            w: number,
-            h: number,
-            cb: Jimp.ImageCallback<T>
-        ): T;
-        scaleToFit(
-            w: number,
-            h: number
-        ): this;
+        scaleToFit<T>(w: number, h: number, cb: Jimp.ImageCallback<T>): T;
+        scaleToFit(w: number, h: number): this;
         scaleToFit<T>(
             w: number,
             h: number,
@@ -525,17 +436,12 @@ declare namespace Jimp {
         ): T;
         displace(map: Jimp, offset: number): this;
         displace<T>(map: Jimp, offset: number, cb: Jimp.ImageCallback<T>): T;
-        autocrop(
-            tolerance?: number,
-            cropOnlyFrames?: boolean,
-        ): this;
+        autocrop(tolerance?: number, cropOnlyFrames?: boolean): this;
         autocrop<T>(
             tolerance: number | undefined | null,
             cb: Jimp.ImageCallback<T>
         ): T;
-        autocrop(
-            cropOnlyFrames: boolean | undefined | null,
-        ): this;
+        autocrop(cropOnlyFrames: boolean | undefined | null): this;
         autocrop<T>(
             cropOnlyFrames: boolean | undefined | null,
             cb: Jimp.ImageCallback<T>
@@ -594,28 +500,15 @@ declare namespace Jimp {
         invert<T>(cb: Jimp.ImageCallback<T>): T;
         gaussian(r: number): this;
         gaussian<T>(r: number, cb: Jimp.ImageCallback<T>): T;
-        composite(
-            src: Jimp,
-            x: number,
-            y: number
-        ): this;
+        composite(src: Jimp, x: number, y: number): this;
         composite<T>(
             src: Jimp,
             x: number,
             y: number,
             cb: Jimp.ImageCallback<T>
         ): T;
-        blit(
-            src: Jimp,
-            x: number,
-            y: number
-        ): this;
-        blit<T>(
-            src: Jimp,
-            x: number,
-            y: number,
-            cb: Jimp.ImageCallback<T>
-        ): T;
+        blit(src: Jimp, x: number, y: number): this;
+        blit<T>(src: Jimp, x: number, y: number, cb: Jimp.ImageCallback<T>): T;
         blit(
             src: Jimp,
             x: number,
@@ -623,7 +516,7 @@ declare namespace Jimp {
             srcx: number,
             srcy: number,
             srcw: number,
-            srch: number,
+            srch: number
         ): this;
         blit<T>(
             src: Jimp,
@@ -642,7 +535,12 @@ declare namespace Jimp {
         static appendConstructorOption<T>(
             name: string,
             test: (...args: T) => boolean,
-            run: (this: this, resolve: (jimp: Jimp) => any, reject: (reason: Error) => any, ...args: T) => any
+            run: (
+                this: this,
+                resolve: (jimp: Jimp) => any,
+                reject: (reason: Error) => any,
+                ...args: T
+            ) => any
         );
         static read(path: string): Promise<Jimp>;
         static read(image: Jimp): Promise<Jimp>;
@@ -652,12 +550,7 @@ declare namespace Jimp {
         static create(image: Jimp): Promise<Jimp>;
         static create(data: Buffer): Promise<Jimp>;
         static create(w: number, h: number, background?: number): Promise<Jimp>;
-        static rgbaToInt(
-            r: number,
-            g: number,
-            b: number,
-            a: number,
-        ): number;
+        static rgbaToInt(r: number, g: number, b: number, a: number): number;
         static rgbaToInt<T>(
             r: number,
             g: number,
@@ -665,10 +558,7 @@ declare namespace Jimp {
             a: number,
             cb: GenericCallback<number, T, Jimp>
         ): T;
-        static intToRGBA(
-            i: number,
-            cb?: GenericCallback<Jimp.RGBA>
-        ): Jimp.RGBA;
+        static intToRGBA(i: number, cb?: GenericCallback<Jimp.RGBA>): Jimp.RGBA;
         static limit255(n: number): number;
         static diff(
             img1: Jimp,
@@ -676,16 +566,13 @@ declare namespace Jimp {
             threshold?: number
         ): { percent: number; image: Jimp };
         static distance(img1: Jimp, img2: Jimp): number;
-        static colorDiff(
-            rgba1: Jimp.RGB,
-            rgba2: Jimp.RGB
-        ): number;
-        static colorDiff(
-            rgba1: Jimp.RGBA,
-            rgba2: Jimp.RGBA
-        ): number;
+        static colorDiff(rgba1: Jimp.RGB, rgba2: Jimp.RGB): number;
+        static colorDiff(rgba1: Jimp.RGBA, rgba2: Jimp.RGBA): number;
         static loadFont(file: string): Promise<Font>;
-        static loadFont(file: string, cb: Jimp.GenericCallback<Font, any, any>): Promise<never>;
+        static loadFont(
+            file: string,
+            cb: Jimp.GenericCallback<Font, any, any>
+        ): Promise<never>;
     }
 }
 

--- a/jimp.d.ts
+++ b/jimp.d.ts
@@ -1,5 +1,6 @@
 declare namespace Jimp {
-    type ImageCallback = (err: Error | null, image: Jimp) => any;
+    type GenericCallback<T> = (err: Error | null, value: T) => any;
+    type ImageCallback = GenericCallback<Jimp>;
 
     interface Bitmap {
         data: Buffer;
@@ -104,20 +105,20 @@ declare namespace Jimp {
         filterType(f: number, cb?: Jimp.ImageCallback): this;
         rgba(bool: boolean, cb?: Jimp.ImageCallback): this;
         quality(n: number, cb?: Jimp.ImageCallback): this;
-        getBase64(mime: string, cb?: (err: Error, src: string) => any): this;
+        getBase64(mime: string, cb?: GenericCallback<string>): this;
         getBase64Async(mime: string): Promise<Jimp>;
-        hash(base?: number, cb?: (err: Error, hash: string) => any): string;
-        getBuffer(mime: string, cb: (err: Error, buffer: Buffer) => any): this;
+        hash(base?: number, cb?: GenericCallback<string>): string;
+        getBuffer(mime: string, cb: GenericCallback<Buffer>): this;
         getBufferAsync(mime: string): Promise<Jimp>;
         getPixelIndex(
             x: number,
             y: number,
-            cb?: (err: Error, i: number) => any
+            cb?: GenericCallback<number>
         ): number;
         getPixelColor(
             x: number,
             y: number,
-            cb?: (err: Error, hex: number) => any
+            cb?: GenericCallback<number>
         ): number;
         setPixelColor(
             hex: number,
@@ -289,11 +290,11 @@ declare namespace Jimp {
             g: number,
             b: number,
             a: number,
-            cb?: (err: Error, i: number) => any
+            cb?: GenericCallback<number>
         ): number;
         static intToRGBA(
             i: number,
-            cb?: (err: Error, rgba: Jimp.RGBA) => any
+            cb?: GenericCallback<Jimp.RGBA>
         ): Jimp.RGBA;
         static limit255(n: number): number;
         static diff(

--- a/jimp.d.ts
+++ b/jimp.d.ts
@@ -19,192 +19,8 @@ declare namespace Jimp {
     }
 
     class Jimp {
-        constructor(path: string, cb?: Jimp.ImageCallback);
-        constructor(image: Jimp, cb?: Jimp.ImageCallback);
-        constructor(data: Buffer, cb?: Jimp.ImageCallback);
-        constructor(w: number, h: number, cb?: Jimp.ImageCallback);
-        constructor(
-            w: number,
-            h: number,
-            background?: number,
-            cb?: Jimp.ImageCallback
-        );
 
-        bitmap: Bitmap;
-
-        clone(cb?: Jimp.ImageCallback): Jimp;
-        quality(n: number, cb?: Jimp.ImageCallback): this;
-        deflateLevel(l: number, cb?: Jimp.ImageCallback): this;
-        deflateStrategy(s: number, cb?: Jimp.ImageCallback): this;
-        filterType(f: number, cb?: Jimp.ImageCallback): this;
-
-        rgba(bool: boolean, cb?: Jimp.ImageCallback): this;
-        background(hex: number, cb?: Jimp.ImageCallback): this;
-        scan(
-            x: number,
-            y: number,
-            w: number,
-            h: number,
-            f: (x: number, y: number, idx: number) => any,
-            cb?: Jimp.ImageCallback
-        ): this;
-        getWidth(): number;
-        getHeight(): number;
-        getMIME(): string;
-        getExtension(): string;
-        getPixelIndex(
-            x: number,
-            y: number,
-            cb?: (err: Error, i: number) => any
-        ): number;
-        getPixelColor(
-            x: number,
-            y: number,
-            cb?: (err: Error, hex: number) => any
-        ): number;
-        setPixelColor(
-            hex: number,
-            x: number,
-            y: number,
-            cb?: Jimp.ImageCallback
-        ): this;
-        hash(base?: number, cb?: (err: Error, hash: string) => any): string;
-        crop(
-            x: number,
-            y: number,
-            w: number,
-            h: number,
-            cb?: Jimp.ImageCallback
-        ): this;
-        autocrop(
-            tolerance?: number,
-            cropOnlyFrames?: boolean,
-            cb?: Jimp.ImageCallback
-        ): this;
-        blit(
-            src: Jimp,
-            x: number,
-            y: number,
-            srcx?: number,
-            srcy?: number,
-            srcw?: number,
-            srch?: number,
-            cb?: Jimp.ImageCallback
-        ): this;
-        mask(src: Jimp, x: number, y: number, cb?: Jimp.ImageCallback): this;
-        composite(
-            src: Jimp,
-            x: number,
-            y: number,
-            cb?: Jimp.ImageCallback
-        ): this;
-        brightness(val: number, cb?: Jimp.ImageCallback): this;
-        contrast(val: number, cb?: Jimp.ImageCallback): this;
-        posterize(n: number, cb?: Jimp.ImageCallback): this;
-        histogram(): { r: number[]; g: number[]; b: number[] };
-        normalize(cb?: Jimp.ImageCallback): this;
-        invert(cb?: Jimp.ImageCallback): this;
-        mirror(
-            horizontal: boolean,
-            vertical: boolean,
-            cb?: Jimp.ImageCallback
-        ): this;
-        flip(
-            horizontal: boolean,
-            vertical: boolean,
-            cb?: Jimp.ImageCallback
-        ): this;
-        gaussian(r: number, cb?: Jimp.ImageCallback): this;
-        blur(r: number, cb?: Jimp.ImageCallback): this;
-        convolution(
-            kernel: any,
-            edgeHandling: number | Jimp.ImageCallback,
-            cb?: Jimp.ImageCallback
-        ): this;
-
-        greyscale(cb?: Jimp.ImageCallback): this;
-        grayscale(cb?: Jimp.ImageCallback): this;
-        sepia(cb?: Jimp.ImageCallback): this;
-        opacity(f: any, cb?: any): this;
-        fade(f: any, cb?: any): this;
-        opaque(cb: any): this;
-        resize(
-            w: number,
-            h: number,
-            mode?: string | Jimp.ImageCallback,
-            cb?: Jimp.ImageCallback
-        ): this;
-        cover(
-            w: number,
-            h: number,
-            alignBits?: number,
-            mode?: string | Jimp.ImageCallback,
-            cb?: Jimp.ImageCallback
-        ): this;
-        contain(
-            w: number,
-            h: number,
-            alignBits?: number,
-            mode?: string | Jimp.ImageCallback,
-            cb?: Jimp.ImageCallback
-        ): this;
-        scale(
-            f: number,
-            mode?: string | Jimp.ImageCallback,
-            cb?: Jimp.ImageCallback
-        ): this;
-        scaleToFit(
-            w: number,
-            h: number,
-            mode?: any,
-            cb?: Jimp.ImageCallback
-        ): this;
-        pixelate(
-            size: number,
-            x: number,
-            y: number,
-            w: number,
-            h: number,
-            cb?: Jimp.ImageCallback
-        ): this;
-        convolute(
-            kernel: any,
-            x: number | Jimp.ImageCallback,
-            y?: number,
-            w?: number,
-            h?: number,
-            cb?: Jimp.ImageCallback
-        ): this;
-        rotate(
-            deg: number,
-            mode?: number | boolean,
-            cb?: Jimp.ImageCallback
-        ): this;
-        exifRotate(): this;
-        displace(map: Jimp, offset: number, cb?: Jimp.ImageCallback): this;
-        getBuffer(mime: string, cb: (err: Error, buffer: Buffer) => any): this;
-        getBufferAsync(mime: string): Promise<Jimp>;
-        getBase64(mime: string, cb?: (err: Error, src: string) => any): this;
-        getBase64Async(mime: string): Promise<Jimp>;
-        dither565(cb?: Jimp.ImageCallback): this;
-        dither16(cb?: Jimp.ImageCallback): this;
-        color(actions: any, cb?: Jimp.ImageCallback): this;
-        colour(actions: any, cb?: Jimp.ImageCallback): this;
-        write(path: string, cb?: Jimp.ImageCallback): this;
-        writeAsync(path: string): Promise<Jimp>;
-        print(
-            font: any,
-            x: number,
-            y: number,
-            text: string,
-            maxWidth?: number | Jimp.ImageCallback,
-            maxHeight?: number | Jimp.ImageCallback,
-            cb?: Jimp.ImageCallback
-        ): this;
-        inspect(): string;
-        toString(): string;
-
-        // used to auto resizing etc.
+        // Constants
         static AUTO: number;
 
         // supported mime types
@@ -259,34 +75,215 @@ declare namespace Jimp {
         static EDGE_WRAP: number;
         static EDGE_CROP: number;
 
-        /* These are constructors, have already moved up, TODO: remove it in the future
-        (path: string, cb?: Jimp.ImageCallback): void;
-        (image: Jimp, cb?: Jimp.ImageCallback): void;
-        (data: Buffer, cb?: Jimp.ImageCallback): void;
-        (w: number, h: number, cb?: Jimp.ImageCallback): void;
-        (w: number, h: number, background?: number, cb?: Jimp.ImageCallback): void;
-        */
+        // Properties
+        bitmap: Bitmap;
 
+        // Constructors
+        constructor(path: string, cb?: Jimp.ImageCallback);
+        constructor(image: Jimp, cb?: Jimp.ImageCallback);
+        constructor(data: Buffer, cb?: Jimp.ImageCallback);
+        constructor(w: number, h: number, cb?: Jimp.ImageCallback);
+        constructor(
+            w: number,
+            h: number,
+            background?: number,
+            cb?: Jimp.ImageCallback
+        );
+
+        // Methods
+        getHeight(): number;
+        getWidth(): number;
+        inspect(): string;
+        toString(): string;
+        getMIME(): string;
+        getExtension(): string;
+        write(path: string, cb?: Jimp.ImageCallback): this;
+        writeAsync(path: string): Promise<Jimp>;
+        deflateLevel(l: number, cb?: Jimp.ImageCallback): this;
+        deflateStrategy(s: number, cb?: Jimp.ImageCallback): this;
+        filterType(f: number, cb?: Jimp.ImageCallback): this;
+        rgba(bool: boolean, cb?: Jimp.ImageCallback): this;
+        quality(n: number, cb?: Jimp.ImageCallback): this;
+        getBase64(mime: string, cb?: (err: Error, src: string) => any): this;
+        getBase64Async(mime: string): Promise<Jimp>;
+        hash(base?: number, cb?: (err: Error, hash: string) => any): string;
+        getBuffer(mime: string, cb: (err: Error, buffer: Buffer) => any): this;
+        getBufferAsync(mime: string): Promise<Jimp>;
+        getPixelIndex(
+            x: number,
+            y: number,
+            cb?: (err: Error, i: number) => any
+        ): number;
+        getPixelColor(
+            x: number,
+            y: number,
+            cb?: (err: Error, hex: number) => any
+        ): number;
+        setPixelColor(
+            hex: number,
+            x: number,
+            y: number,
+            cb?: Jimp.ImageCallback
+        ): this;
+        clone(cb?: Jimp.ImageCallback): Jimp;
+        background(hex: number, cb?: Jimp.ImageCallback): this;
+        scan(
+            x: number,
+            y: number,
+            w: number,
+            h: number,
+            f: (x: number, y: number, idx: number) => any,
+            cb?: Jimp.ImageCallback
+        ): this;
+        crop(
+            x: number,
+            y: number,
+            w: number,
+            h: number,
+            cb?: Jimp.ImageCallback
+        ): this;
+
+        // Color methods
+        brightness(val: number, cb?: Jimp.ImageCallback): this;
+        contrast(val: number, cb?: Jimp.ImageCallback): this;
+        posterize(n: number, cb?: Jimp.ImageCallback): this;
+        greyscale(cb?: Jimp.ImageCallback): this;
+        grayscale(cb?: Jimp.ImageCallback): this;
+        opacity(f: any, cb?: any): this;
+        sepia(cb?: Jimp.ImageCallback): this;
+        fade(f: any, cb?: any): this;
+        convolution(
+            kernel: any,
+            edgeHandling: number | Jimp.ImageCallback,
+            cb?: Jimp.ImageCallback
+        ): this;
+        opaque(cb: any): this;
+        pixelate(
+            size: number,
+            x: number,
+            y: number,
+            w: number,
+            h: number,
+            cb?: Jimp.ImageCallback
+        ): this;
+        convolute(
+            kernel: any,
+            x: number | Jimp.ImageCallback,
+            y?: number,
+            w?: number,
+            h?: number,
+            cb?: Jimp.ImageCallback
+        ): this;
+        color(actions: any, cb?: Jimp.ImageCallback): this;
+        colour(actions: any, cb?: Jimp.ImageCallback): this;
+
+        // Shape methods
+        rotate(
+            deg: number,
+            mode?: number | boolean,
+            cb?: Jimp.ImageCallback
+        ): this;
+        flip(
+            horizontal: boolean,
+            vertical: boolean,
+            cb?: Jimp.ImageCallback
+        ): this;
+        mirror(
+            horizontal: boolean,
+            vertical: boolean,
+            cb?: Jimp.ImageCallback
+        ): this;
+        resize(
+            w: number,
+            h: number,
+            mode?: string | Jimp.ImageCallback,
+            cb?: Jimp.ImageCallback
+        ): this;
+        cover(
+            w: number,
+            h: number,
+            alignBits?: number,
+            mode?: string | Jimp.ImageCallback,
+            cb?: Jimp.ImageCallback
+        ): this;
+        contain(
+            w: number,
+            h: number,
+            alignBits?: number,
+            mode?: string | Jimp.ImageCallback,
+            cb?: Jimp.ImageCallback
+        ): this;
+        scale(
+            f: number,
+            mode?: string | Jimp.ImageCallback,
+            cb?: Jimp.ImageCallback
+        ): this;
+        scaleToFit(
+            w: number,
+            h: number,
+            mode?: any,
+            cb?: Jimp.ImageCallback
+        ): this;
+        displace(map: Jimp, offset: number, cb?: Jimp.ImageCallback): this;
+        autocrop(
+            tolerance?: number,
+            cropOnlyFrames?: boolean,
+            cb?: Jimp.ImageCallback
+        ): this;
+
+        // Text methods
+        print(
+            font: any,
+            x: number,
+            y: number,
+            text: string,
+            maxWidth?: number | Jimp.ImageCallback,
+            maxHeight?: number | Jimp.ImageCallback,
+            cb?: Jimp.ImageCallback
+        ): this;
+
+        // Effect methods
+        blur(r: number, cb?: Jimp.ImageCallback): this;
+        dither565(cb?: Jimp.ImageCallback): this;
+        dither16(cb?: Jimp.ImageCallback): this;
+        histogram(): { r: number[]; g: number[]; b: number[] };
+        normalize(cb?: Jimp.ImageCallback): this;
+        invert(cb?: Jimp.ImageCallback): this;
+        gaussian(r: number, cb?: Jimp.ImageCallback): this;
+        composite(
+            src: Jimp,
+            x: number,
+            y: number,
+            cb?: Jimp.ImageCallback
+        ): this;
+        blit(
+            src: Jimp,
+            x: number,
+            y: number,
+            srcx?: number,
+            srcy?: number,
+            srcw?: number,
+            srch?: number,
+            cb?: Jimp.ImageCallback
+        ): this;
+        mask(src: Jimp, x: number, y: number, cb?: Jimp.ImageCallback): this;
+
+        // Functions
         static appendConstructorOption(
             name: string,
             test: Function,
             run: Function
         );
-
         static read(path: string): Promise<Jimp>;
         static read(image: Jimp): Promise<Jimp>;
         static read(data: Buffer): Promise<Jimp>;
         static read(w: number, h: number): Promise<Jimp>;
         static read(w: number, h: number, background?: number): Promise<Jimp>;
-
         static create(path: string): Promise<Jimp>;
         static create(image: Jimp): Promise<Jimp>;
         static create(data: Buffer): Promise<Jimp>;
         static create(w: number, h: number): Promise<Jimp>;
         static create(w: number, h: number, background?: number): Promise<Jimp>;
-
-        static loadFont(file: string, cb?: Jimp.ImageCallback): Promise<any>;
-
         static rgbaToInt(
             r: number,
             g: number,
@@ -305,11 +302,11 @@ declare namespace Jimp {
             threshold?: number
         ): { percent: number; image: Jimp };
         static distance(img1: Jimp, img2: Jimp): number;
-
         static colorDiff(
             rgba1: Jimp.RGB | Jimp.RGBA,
             rgba2: Jimp.RGB | Jimp.RGBA
         ): number;
+        static loadFont(file: string, cb?: Jimp.ImageCallback): Promise<any>;
     }
 }
 

--- a/jimp.d.ts
+++ b/jimp.d.ts
@@ -22,38 +22,38 @@ declare namespace Jimp {
     class Jimp {
 
         // Constants
-        static AUTO: number;
+        static AUTO: -1;
 
         // supported mime types
-        static MIME_PNG: string;
-        static MIME_JPEG: string;
-        static MIME_JGD: string;
-        static MIME_BMP: string;
-        static MIME_X_MS_BMP: string;
-        static MIME_GIF: string;
+        static MIME_PNG: 'image/png';
+        static MIME_JPEG: 'image/jpeg';
+        static MIME_JGD: 'image/jgd';
+        static MIME_BMP: 'image/bmp';
+        static MIME_X_MS_BMP: 'image/x-ms-bmp';
+        static MIME_GIF: 'image/gif';
         // PNG filter types
-        static PNG_FILTER_AUTO: number;
-        static PNG_FILTER_NONE: number;
-        static PNG_FILTER_SUB: number;
-        static PNG_FILTER_UP: number;
-        static PNG_FILTER_AVERAGE: number;
-        static PNG_FILTER_PATH: number;
+        static PNG_FILTER_AUTO: -1;
+        static PNG_FILTER_NONE: 0;
+        static PNG_FILTER_SUB: 1;
+        static PNG_FILTER_UP: 2;
+        static PNG_FILTER_AVERAGE: 3;
+        static PNG_FILTER_PATH: 4;
 
         // resize methods
-        static RESIZE_NEAREST_NEIGHBOR: string;
-        static RESIZE_BILINEAR: string;
-        static RESIZE_BICUBIC: string;
-        static RESIZE_HERMITE: string;
-        static RESIZE_BEZIER: string;
+        static RESIZE_NEAREST_NEIGHBOR: 'nearestNeighbor';
+        static RESIZE_BILINEAR: 'bilinearInterpolation';
+        static RESIZE_BICUBIC: 'bicubicInterpolation';
+        static RESIZE_HERMITE: 'hermiteInterpolation';
+        static RESIZE_BEZIER: 'bezierInterpolation';
 
         // Align modes for cover, contain, bit masks
-        static HORIZONTAL_ALIGN_LEFT: number;
-        static HORIZONTAL_ALIGN_CENTER: number;
-        static HORIZONTAL_ALIGN_RIGHT: number;
+        static HORIZONTAL_ALIGN_LEFT: 1;
+        static HORIZONTAL_ALIGN_CENTER: 2;
+        static HORIZONTAL_ALIGN_RIGHT: 4;
 
-        static VERTICAL_ALIGN_TOP: number;
-        static VERTICAL_ALIGN_MIDDLE: number;
-        static VERTICAL_ALIGN_BOTTOM: number;
+        static VERTICAL_ALIGN_TOP: 8;
+        static VERTICAL_ALIGN_MIDDLE: 16;
+        static VERTICAL_ALIGN_BOTTOM: 32;
 
         // Font locations
         static FONT_SANS_8_BLACK: string;
@@ -72,9 +72,9 @@ declare namespace Jimp {
         static FONT_SANS_128_WHITE: string;
 
         // Edge Handling
-        static EDGE_EXTEND: number;
-        static EDGE_WRAP: number;
-        static EDGE_CROP: number;
+        static EDGE_EXTEND: 1;
+        static EDGE_WRAP: 2;
+        static EDGE_CROP: 3;
 
         // Properties
         bitmap: Bitmap;

--- a/jimp.d.ts
+++ b/jimp.d.ts
@@ -101,6 +101,7 @@ declare namespace Jimp {
 
         // supported mime types
         static MIME_PNG: 'image/png';
+        static MIME_TIFF: 'image/tiff';
         static MIME_JPEG: 'image/jpeg';
         static MIME_JGD: 'image/jgd';
         static MIME_BMP: 'image/bmp';

--- a/jimp.d.ts
+++ b/jimp.d.ts
@@ -16,6 +16,34 @@ declare namespace Jimp {
         | 'hue';
     type ColorAction = { apply: ColorActionName; params: any };
 
+    type ChangeName = 'background' | 'scan' | 'crop';
+
+    type ListenableName =
+        | 'any'
+        | 'initialized'
+        | 'before-change'
+        | 'changed'
+        | 'before-clone'
+        | 'cloned'
+        | ChangeName;
+
+    type ListenerData<T extends ListenableName> = T extends 'any'
+        ? any
+        : T extends ChangeName
+            ? {
+                  eventName: 'before-change' | 'changed';
+                  methodName: T;
+                  [key: string]: any;
+              }
+            : {
+                  eventName: T;
+                  methodName: T extends 'initialized'
+                      ? 'constructor'
+                      : T extends 'before-change' | 'changed'
+                          ? ChangeName
+                          : T extends 'before-clone' | 'cloned' ? 'clone' : any;
+              };
+
     type PrintableText =
         | string
         | {
@@ -175,9 +203,13 @@ declare namespace Jimp {
             cb?: Jimp.ImageCallback
         );
         // For custom constructors when using Jimp.appendConstructorOption
-        constructor(...args: any[])
+        constructor(...args: any[]);
 
         // Methods
+        on<T extends ListenableName>(
+            event: T,
+            cb: (data: ListenerData<T>) => any
+        ): any;
         getHeight(): number;
         getWidth(): number;
         inspect(): string;

--- a/jimp.d.ts
+++ b/jimp.d.ts
@@ -1,6 +1,8 @@
 declare namespace Jimp {
-    type GenericCallback<T> = (err: Error | null, value: T) => any;
-    type ImageCallback = GenericCallback<Jimp>;
+    type GenericCallback<T, U = any, TThis = any> = (this: TThis, err: Error | null, value: T) => U;
+    type ImageCallback<U = any> = GenericCallback<Jimp, U, Jimp>;
+    type ColorActionName = 'mix' | 'tint' | 'shade' | 'xor' | 'red' | 'green' | 'blue' | 'hue';
+    type ColorAction = { apply: ColorActionName, params: any };
 
     interface Bitmap {
         data: Buffer;
@@ -100,132 +102,368 @@ declare namespace Jimp {
         getExtension(): string;
         write(path: string, cb?: Jimp.ImageCallback): this;
         writeAsync(path: string): Promise<Jimp>;
-        deflateLevel(l: number, cb?: Jimp.ImageCallback): this;
-        deflateStrategy(s: number, cb?: Jimp.ImageCallback): this;
-        filterType(f: number, cb?: Jimp.ImageCallback): this;
-        rgba(bool: boolean, cb?: Jimp.ImageCallback): this;
-        quality(n: number, cb?: Jimp.ImageCallback): this;
-        getBase64(mime: string, cb?: GenericCallback<string>): this;
+        deflateLevel(l: number): this;
+        deflateLevel<T>(l: number, cb: Jimp.ImageCallback<T>): T;
+        deflateStrategy(s: number): this;
+        deflateStrategy<T>(s: number, cb: Jimp.ImageCallback<T>): T;
+        filterType(f: number): this;
+        filterType<T>(f: number, cb: Jimp.ImageCallback<T>): T;
+        rgba(bool: boolean): this;
+        rgba<T>(bool: boolean, cb: Jimp.ImageCallback<T>): T;
+        quality(n: number): this;
+        quality<T>(n: number, cb: Jimp.ImageCallback<T>): T;
+        getBase64(mime: string, cb?: GenericCallback<string, any, this>): this;
         getBase64Async(mime: string): Promise<Jimp>;
-        hash(base?: number, cb?: GenericCallback<string>): string;
+        hash(base?: number): string;
+        hash<T>(cb: GenericCallback<string, T, this>): T;
+        hash<T>(base: number | null | undefined, cb: GenericCallback<string, T, this>): T;
         getBuffer(mime: string, cb: GenericCallback<Buffer>): this;
-        getBufferAsync(mime: string): Promise<Jimp>;
+        getBufferAsync(mime: string): Promise<Buffer>;
+        getPixelIndex<T>(
+            x: number,
+            y: number,
+            cb: GenericCallback<number, T, this>
+        ): T;
         getPixelIndex(
             x: number,
             y: number,
-            cb?: GenericCallback<number>
+            edgeHandling?: string
         ): number;
+        getPixelIndex<T>(
+            x: number,
+            y: number,
+            edgeHandling: string,
+            cb: GenericCallback<number, T, this>
+        ): T;
         getPixelColor(
             x: number,
             y: number,
-            cb?: GenericCallback<number>
         ): number;
+        getPixelColor<T>(
+            x: number,
+            y: number,
+            cb: GenericCallback<number, T, this>
+        ): T;
+        getPixelColour(
+            x: number,
+            y: number,
+        ): number;
+        getPixelColour<T>(
+            x: number,
+            y: number,
+            cb: GenericCallback<number, T, this>
+        ): T;
         setPixelColor(
             hex: number,
             x: number,
             y: number,
-            cb?: Jimp.ImageCallback
         ): this;
-        clone(cb?: Jimp.ImageCallback): Jimp;
-        background(hex: number, cb?: Jimp.ImageCallback): this;
+        setPixelColor<T>(
+            hex: number,
+            x: number,
+            y: number,
+            cb: Jimp.ImageCallback<T>
+        ): T;
+        setPixelColour(
+            hex: number,
+            x: number,
+            y: number,
+        ): this;
+        setPixelColour<T>(
+            hex: number,
+            x: number,
+            y: number,
+            cb: Jimp.ImageCallback<T>
+        ): T;
+        clone(): Jimp;
+        clone<T>(cb: Jimp.ImageCallback<T>): T;
+        cloneQuiet(): Jimp;
+        cloneQuiet<T>(cb: Jimp.ImageCallback<T>): T;
+        background(hex: number): this;
+        background<T>(hex: number, cb: Jimp.ImageCallback<T>): T;
+        backgroundQuiet(hex: number): this;
+        backgroundQuiet<T>(hex: number, cb: Jimp.ImageCallback<T>): T;
         scan(
             x: number,
             y: number,
             w: number,
             h: number,
-            f: (x: number, y: number, idx: number) => any,
-            cb?: Jimp.ImageCallback
+            f: (this: this, x: number, y: number, idx: number) => any,
         ): this;
+        scan<T>(
+            x: number,
+            y: number,
+            w: number,
+            h: number,
+            f: (this: this, x: number, y: number, idx: number) => any,
+            cb: Jimp.ImageCallback<T>
+        ): T;
+        scanQuiet(
+            x: number,
+            y: number,
+            w: number,
+            h: number,
+            f: (this: this, x: number, y: number, idx: number) => any,
+        ): this;
+        scanQuiet<T>(
+            x: number,
+            y: number,
+            w: number,
+            h: number,
+            f: (this: this, x: number, y: number, idx: number) => any,
+            cb: Jimp.ImageCallback<T>
+        ): T;
         crop(
             x: number,
             y: number,
             w: number,
             h: number,
-            cb?: Jimp.ImageCallback
         ): this;
+        crop<T>(
+            x: number,
+            y: number,
+            w: number,
+            h: number,
+            cb: Jimp.ImageCallback<T>
+        ): T;
+        cropQuiet(
+            x: number,
+            y: number,
+            w: number,
+            h: number,
+        ): this;
+        cropQuiet<T>(
+            x: number,
+            y: number,
+            w: number,
+            h: number,
+            cb: Jimp.ImageCallback<T>
+        ): T;
 
         // Color methods
-        brightness(val: number, cb?: Jimp.ImageCallback): this;
-        contrast(val: number, cb?: Jimp.ImageCallback): this;
-        posterize(n: number, cb?: Jimp.ImageCallback): this;
-        greyscale(cb?: Jimp.ImageCallback): this;
-        grayscale(cb?: Jimp.ImageCallback): this;
-        opacity(f: any, cb?: any): this;
-        sepia(cb?: Jimp.ImageCallback): this;
-        fade(f: any, cb?: any): this;
+        brightness(val: number): this;
+        brightness<T>(val: number, cb: Jimp.ImageCallback<T>): T;
+        contrast(val: number): this;
+        contrast<T>(val: number, cb: Jimp.ImageCallback<T>): T;
+        posterize(n: number): this;
+        posterize<T>(n: number, cb: Jimp.ImageCallback<T>): T;
+        greyscale(): this;
+        greyscale<T>(cb: Jimp.ImageCallback<T>): T;
+        grayscale(): this;
+        grayscale<T>(cb: Jimp.ImageCallback<T>): T;
+        opacity(f: number): this;
+        opacity<T>(f: number, cb: Jimp.ImageCallback<T>): T;
+        sepia(): this;
+        sepia<T>(cb: Jimp.ImageCallback<T>): T;
+        fade(f: number): this;
+        fade<T>(f: number, cb: Jimp.ImageCallback<T>): T;
         convolution(
-            kernel: any,
-            edgeHandling: number | Jimp.ImageCallback,
-            cb?: Jimp.ImageCallback
+            kernel: number[][],
         ): this;
-        opaque(cb: any): this;
+        convolution<T>(
+            kernel: number[][],
+            cb: Jimp.ImageCallback<T>
+        ): T;
+        convolution(
+            kernel: number[][],
+            edgeHandling: string
+        ): this;
+        convolution<T>(
+            kernel: number[][],
+            edgeHandling: string,
+            cb: Jimp.ImageCallback<T>
+        ): T;
+        opaque(): this;
+        opaque<T>(cb: Jimp.ImageCallback<T>): T;
+        pixelate<T>(
+            size: number,
+            cb: Jimp.ImageCallback<T>
+        ): T;
         pixelate(
             size: number,
             x: number,
             y: number,
             w: number,
             h: number,
-            cb?: Jimp.ImageCallback
         ): this;
+        pixelate<T>(
+            size: number,
+            x: number,
+            y: number,
+            w: number,
+            h: number,
+            cb: Jimp.ImageCallback<T>
+        ): T;
+        convolute<T>(
+            kernel: number[][],
+            cb: Jimp.ImageCallback<T>
+        ): T;
         convolute(
-            kernel: any,
-            x: number | Jimp.ImageCallback,
-            y?: number,
-            w?: number,
-            h?: number,
-            cb?: Jimp.ImageCallback
+            kernel: number[][],
+            x: number,
+            y: number,
+            w: number,
+            h: number,
         ): this;
-        color(actions: any, cb?: Jimp.ImageCallback): this;
-        colour(actions: any, cb?: Jimp.ImageCallback): this;
+        convolute<T>(
+            kernel: number[][],
+            x: number,
+            y: number,
+            w: number,
+            h: number,
+            cb: Jimp.ImageCallback<T>
+        ): T;
+        color(actions: ColorAction[]): this;
+        color<T>(actions: ColorAction[], cb: Jimp.ImageCallback<T>): T;
+        colour(actions: ColorAction[]): this;
+        colour<T>(actions: ColorAction[], cb: Jimp.ImageCallback<T>): T;
 
         // Shape methods
+        rotate<T>(
+            deg: number,
+            cb: Jimp.ImageCallback<T>
+        ): T;
         rotate(
             deg: number,
             mode?: number | boolean,
-            cb?: Jimp.ImageCallback
         ): this;
+        rotate<T>(
+            deg: number,
+            mode: number | boolean | undefined | null,
+            cb: Jimp.ImageCallback<T>
+        ): T;
         flip(
             horizontal: boolean,
-            vertical: boolean,
-            cb?: Jimp.ImageCallback
+            vertical: boolean
         ): this;
-        mirror(
+        flip<T>(
             horizontal: boolean,
             vertical: boolean,
-            cb?: Jimp.ImageCallback
+            cb: Jimp.ImageCallback<T>
+        ): T;
+        mirror(
+            horizontal: boolean,
+            vertical: boolean
         ): this;
+        mirror<T>(
+            horizontal: boolean,
+            vertical: boolean,
+            cb: Jimp.ImageCallback<T>
+        ): T;
+        resize<T>(
+            w: number,
+            h: number,
+            cb: Jimp.ImageCallback<T>
+        ): T;
         resize(
             w: number,
             h: number,
-            mode?: string | Jimp.ImageCallback,
-            cb?: Jimp.ImageCallback
+            mode?: string
         ): this;
+        resize<T>(
+            w: number,
+            h: number,
+            mode: string | undefined | null,
+            cb: Jimp.ImageCallback<T>
+        ): T;
+        cover<T>(
+            w: number,
+            h: number,
+            cb: Jimp.ImageCallback<T>
+        ): T;
+        cover<T>(
+            w: number,
+            h: number,
+            alignBits: number | undefined | null,
+            cb: Jimp.ImageCallback<T>
+        ): T;
         cover(
             w: number,
             h: number,
             alignBits?: number,
-            mode?: string | Jimp.ImageCallback,
-            cb?: Jimp.ImageCallback
+            mode?: string
         ): this;
+        cover<T>(
+            w: number,
+            h: number,
+            alignBits: number | undefined | null,
+            mode: string | undefined | null,
+            cb: Jimp.ImageCallback<T>
+        ): T;
+        contain(
+            w: number,
+            h: number
+        ): this;
+        contain<T>(
+            w: number,
+            h: number,
+            cb: Jimp.ImageCallback<T>
+        ): T;
         contain(
             w: number,
             h: number,
-            alignBits?: number,
-            mode?: string | Jimp.ImageCallback,
-            cb?: Jimp.ImageCallback
+            mode: string
         ): this;
-        scale(
-            f: number,
-            mode?: string | Jimp.ImageCallback,
-            cb?: Jimp.ImageCallback
-        ): this;
-        scaleToFit(
+        contain<T>(
             w: number,
             h: number,
-            mode?: any,
-            cb?: Jimp.ImageCallback
+            mode: string,
+            cb: Jimp.ImageCallback<T>
+        ): T;
+        contain(
+            w: number,
+            h: number,
+            alignBits: number
         ): this;
-        displace(map: Jimp, offset: number, cb?: Jimp.ImageCallback): this;
+        contain<T>(
+            w: number,
+            h: number,
+            alignBits: number,
+            cb: Jimp.ImageCallback<T>
+        ): T;
+        contain(
+            w: number,
+            h: number,
+            alignBits: number,
+            mode: string
+        ): this;
+        contain<T>(
+            w: number,
+            h: number,
+            alignBits: number,
+            mode: string,
+            cb: Jimp.ImageCallback<T>
+        ): T;
+        scale<T>(
+            f: number,
+            cb: Jimp.ImageCallback<T>
+        ): T;
+        scale(
+            f: number,
+            mode?: string
+        ): this;
+        scale<T>(
+            f: number,
+            mode: string | undefined | null,
+            cb: Jimp.ImageCallback<T>
+        ): T;
+        scaleToFit<T>(
+            w: number,
+            h: number,
+            cb: Jimp.ImageCallback<T>
+        ): T;
+        scaleToFit(
+            w: number,
+            h: number
+        ): this;
+        scaleToFit<T>(
+            w: number,
+            h: number,
+            mode: string | undefined | null,
+            cb: Jimp.ImageCallback<T>
+        ): T;
+        displace(map: Jimp, offset: number): this;
+        displace<T>(map: Jimp, offset: number, cb: Jimp.ImageCallback<T>): T;
         autocrop(
             tolerance?: number,
             cropOnlyFrames?: boolean,

--- a/jimp.d.ts
+++ b/jimp.d.ts
@@ -165,6 +165,8 @@ declare namespace Jimp {
             background?: number,
             cb?: Jimp.ImageCallback
         );
+        // For custom constructors when using Jimp.appendConstructorOption
+        constructor(...args: any[])
 
         // Methods
         getHeight(): number;
@@ -532,11 +534,11 @@ declare namespace Jimp {
         mask<T>(src: Jimp, x: number, y: number, cb: Jimp.ImageCallback<T>): T;
 
         // Functions
-        static appendConstructorOption<T>(
+        static appendConstructorOption<T extends any[]>(
             name: string,
             test: (...args: T) => boolean,
             run: (
-                this: this,
+                this: Jimp,
                 resolve: (jimp: Jimp) => any,
                 reject: (reason: Error) => any,
                 ...args: T

--- a/jimp.d.ts
+++ b/jimp.d.ts
@@ -155,6 +155,14 @@ declare namespace Jimp {
         // Properties
         bitmap: Bitmap;
 
+        private _quality: number;
+        private _deflateLevel: number;
+        private _deflateStrategy: number;
+        private _filterType: number;
+        private _rgba: boolean;
+        private _background: number;
+        private _originalMime: string;
+
         // Constructors
         constructor(path: string, cb?: Jimp.ImageCallback);
         constructor(image: Jimp, cb?: Jimp.ImageCallback);


### PR DESCRIPTION
Includes constants and correct return types for functions with callback.
To import Jimp correctly to your TypeScript project, import it like so: `import Jimp = require('jimp')`
