### PR TITLE
Replace the usage of stream-to-buffer with raw-body

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ var MIME = require("mime");
 var TinyColor = require("tinycolor2");
 var Resize = require("./resize.js");
 var Resize2 = require("./resize2.js");
-var StreamToBuffer = require("stream-to-buffer");
+var RawBody = require("raw-body");
 var FileType = require("file-type");
 var PixelMatch = require("pixelmatch");
 var EXIFParser = require("exif-parser");
@@ -2406,7 +2406,7 @@ Jimp.prototype.getBuffer = function (mime, cb) {
             if (this._rgba) png.data = new Buffer(this.bitmap.data);
             else png.data = compositeBitmapOverBackground(this).data; // when PNG doesn't support alpha
 
-            StreamToBuffer(png.pack(), function (err, buffer) {
+            RawBody(png.pack(), {}, function (err, buffer) {
                 if (err) return throwError.call(this, err, cb);
                 return cb.call(that, null, buffer);
             });

--- a/package.json
+++ b/package.json
@@ -51,8 +51,8 @@
     "mkdirp": "0.5.1",
     "pixelmatch": "^4.0.0",
     "pngjs": "^3.0.0",
+    "raw-body": "^2.3.2",
     "request": "^2.65.0",
-    "stream-to-buffer": "^0.1.0",
     "tinycolor2": "^1.1.2"
   },
   "devDependencies": {


### PR DESCRIPTION
stream-to-buffer is deprecated (https://www.npmjs.com/package/stream-to-buffer)
and raw-body from stream-utils is the pointed to replacement.