### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Jimp.read("http://www.example.com/path/to/lenna.jpg").then(function (image) {
 
 ### Basic methods ###
 
-Once the the promise is fulfilled, the following methods can be called on the image:
+Once the promise is fulfilled, the following methods can be called on the image:
 
 ```js
 /* Resize */

--- a/README.md
+++ b/README.md
@@ -36,13 +36,9 @@ Jimp.read("lenna.png").then(function (lenna) {
 
 ## Basic usage ##
 
-The static `Jimp.read` method takes the path to a PNG, JPEG or BMP file and (optionally) a Node-style callback and returns a Promise:
+The static `Jimp.read` method takes the path to a PNG, JPEG or BMP file and returns a Promise:
 
 ```js
-Jimp.read("./path/to/image.jpg", function (err, image) {
-    // do stuff with the image (if no exception)
-});
-
 Jimp.read("./path/to/image.jpg").then(function (image) {
     // do stuff with the image
 }).catch(function (err) {
@@ -53,19 +49,23 @@ Jimp.read("./path/to/image.jpg").then(function (image) {
 The method can also read a PNG, JPEG or BMP buffer or from a URL:
 
 ```js
-Jimp.read(lenna.buffer, function (err, image) {
-    // do stuff with the image (if no exception)
+Jimp.read(lenna.buffer).then(function (image) {
+    // do stuff with the image
+}).catch(function (err) {
+    // handle an exception
 });
 
-Jimp.read("http://www.example.com/path/to/lenna.jpg", function (err, image) {
-    // do stuff with the image (if no exception)
+Jimp.read("http://www.example.com/path/to/lenna.jpg").then(function (image) {
+    // do stuff with the image
+}).catch(function (err) {
+    // handle an exception
 });
 ```
 
 
 ### Basic methods ###
 
-Once the callback is filed or the promise fulfilled, the following methods can be called on the image:
+Once the the promise is fulfilled, the following methods can be called on the image:
 
 ```js
 /* Resize */


### PR DESCRIPTION
The current `README.md` file shows the use of Node.js-style callbacks in the `Jimp.read` function. Sadly, this is simply incorrect as of January 10th, 2018 in the current `master` branch (see that there is no callback argument [here](https://github.com/oliver-moran/jimp/blob/master/index.js#L325)).

An alternative solution would be to implement callbacks into the code, but I believe that moving towards promises will increase the longevity of this package and encourage other package maintainers/collaborators to do the same.