### PR TITLE
Fix - Allow for 0 threshold in Jimp.diff

### DIFF
--- a/index.js
+++ b/index.js
@@ -613,7 +613,7 @@ Jimp.diff = function (img1, img2, threshold) {
         }
     }
 
-    threshold = threshold || 0.1;
+    threshold = isDef(threshold) ? threshold : 0.1;
     if (typeof threshold !== "number" || threshold < 0 || threshold > 1)
         return throwError.call(this, "threshold must be a number between 0 and 1");
 

--- a/test/compare.test.js
+++ b/test/compare.test.js
@@ -81,4 +81,13 @@ describe("Compare image difference", ()=> {
         });
     });
 
+    it('allows to set a different threshold', ()=> {
+        Jimp.diff(imgs[0], imgs[3], 0.1).percent.should.be.equal(0);
+        Jimp.diff(imgs[0], imgs[3], 0).percent.should.be.equal(0.25);
+    });
+
+    it('throws an error if threshold is invalid', ()=> {
+        (()=> Jimp.diff(imgs[0], imgs[3], 'invalid')).should.throw('threshold must be a number between 0 and 1');
+    });
+
 });


### PR DESCRIPTION
As you can see in [Pixelmatch](https://github.com/mapbox/pixelmatch/blob/master/index.js#L11):
```javascript
 var threshold = options.threshold === undefined ? 0.1 : options.threshold;
```

They allow for 0 threshold, which we need for some of our comparisons.

I've provided additional tests as well, feel free to point out if I missed anything :)