### PR TITLE
Optimize text printing

### DIFF
--- a/index.js
+++ b/index.js
@@ -2726,7 +2726,7 @@ function drawCharacter (image, font, x, y, char) {
     if (char.width > 0 && char.height > 0) {
         var imageChar = char.image
         if (!imageChar){
-            imageChar = font.pages[char.page].clone().crop(char.x, char.y, char.width, char.height);
+            imageChar = font.pages[char.page].cloneQuiet().crop(char.x, char.y, char.width, char.height);
             char.image = imageChar
         }
         return image.composite(imageChar, x + char.xoffset, y + char.yoffset);

--- a/index.js
+++ b/index.js
@@ -2724,7 +2724,11 @@ function printText (font, x, y, text) {
 
 function drawCharacter (image, font, x, y, char) {
     if (char.width > 0 && char.height > 0) {
-        var imageChar = font.pages[char.page].cloneQuiet().crop(char.x, char.y, char.width, char.height);
+        var imageChar = char.image
+        if (!imageChar){
+            imageChar = font.pages[char.page].clone().crop(char.x, char.y, char.width, char.height);
+            char.image = imageChar
+        }
         return image.composite(imageChar, x + char.xoffset, y + char.yoffset);
     }
     return image;

--- a/resize2.js
+++ b/resize2.js
@@ -37,8 +37,8 @@ module.exports = {
             for (let j = 0; j < wDst; j++) {
                 var posDst = (i * wDst + j) * 4;
 
-                var iSrc = Math.round(i * hSrc / hDst);
-                var jSrc = Math.round(j * wSrc / wDst);
+                var iSrc = Math.floor(i * hSrc / hDst);
+                var jSrc = Math.floor(j * wSrc / wDst);
                 var posSrc = (iSrc * wSrc + jSrc) * 4;
 
                 bufDst[posDst++] = bufSrc[posSrc++];


### PR DESCRIPTION
by saving character images in the font on drawCharacter() rather than make a new jimp every time, giving a noticeable and measurable speed boost.