### PR TITLE
Extendable Jimp TypeScript interface

### DIFF
--- a/jimp.d.ts
+++ b/jimp.d.ts
@@ -75,7 +75,7 @@ declare namespace Jimp {
         toString(): string;
     }
 
-    var Jimp: {
+    interface JimpEntry<T extends Jimp> {
 
         // used to auto resizing etc.
         AUTO: number;
@@ -133,27 +133,29 @@ declare namespace Jimp {
         EDGE_WRAP: number;
         EDGE_CROP: number;
 
-        (path: string, cb?: Jimp.ImageCallback): void;
-        (image: Jimp, cb?: Jimp.ImageCallback): void;
-        (data: Buffer, cb?: Jimp.ImageCallback): void;
-        (w: number, h: number, cb?: Jimp.ImageCallback): void;
-        (w: number, h: number, background?: number, cb?: Jimp.ImageCallback): void;
+        (path: string, cb?: T.ImageCallback): void;
+        (image: T, cb?: T.ImageCallback): void;
+        (data: Buffer, cb?: T.ImageCallback): void;
+        (w: number, h: number, cb?: T.ImageCallback): void;
+        (w: number, h: number, background?: number, cb?: T.ImageCallback): void;
 
-        read(src: string | Buffer, cb?: Jimp.ImageCallback): Promise<Jimp>;
-        loadFont(file: string, cb?: Jimp.ImageCallback): Promise<any>;
+        read(src: string | Buffer, cb?: T.ImageCallback): Promise<T>;
+        loadFont(file: string, cb?: T.ImageCallback): Promise<any>;
 
         rgbaToInt(r: number, g: number, b: number, a: number, cb?: (err: Error, i: number)=>any): number;
-        intToRGBA(i: number, cb?: (err:Error, rgba: Jimp.RGBA)=>any): Jimp.RGBA;
+        intToRGBA(i: number, cb?: (err:Error, rgba: T.RGBA)=>any): T.RGBA;
         limit255(n: number): number;
-        diff(img1: Jimp, img2: Jimp, threshold?: number): {percent: number, diff: Jimp};
-        distance(img1: Jimp, img2: Jimp): number;
+        diff(img1: T, img2: T, threshold?: number): {percent: number, diff: T};
+        distance(img1: T, img2: T): number;
 
-        colorDiff(rgba1: Jimp.RGB | Jimp.RGBA, rgba2: Jimp.RGB | Jimp.RGBA): number;
+        colorDiff(rgba1: T.RGB | T.RGBA, rgba2: T.RGB | T.RGBA): number;
 
-        prototype: Jimp;
-    };
+        prototype: T;
+    }
+
+    var jimpEntry: JimpEntry<Jimp>
 }
 
 declare module "jimp" {
-    export = Jimp.Jimp;
+    export = Jimp.jimpEntry;
 }


### PR DESCRIPTION
This PR allows Jimp TypeScript interface to be extended.

For example I promisifed the `getBuffer()` method as

```js
myjimp.prototype.getBufferAsync = util.promisify(jimp.prototype.getBuffer)
```

But without this PR I couldn't extend the interface because the entry point was a variable, rather than an interface. The variable's entry methods returned the interface.

With this PR I am able to do this easily:

```js
import jimp from 'jimp'
import util from 'util'

interface MyJimp extends Jimp.Jimp {
	getBufferAsync(mime: string): Promise<Buffer>
}

interface MyJimpEntry extends Jimp.JimpEntry<MyJimp> {
	prototype: MyJimp
}

const myjimp: MyJimpEntry = <MyJimpEntry> jimp

myjimp.prototype.getBufferAsync = util.promisify(jimp.prototype.getBuffer)

export default myjimp
```

And when I am chaining methods it still works and I am getting "MyJimp" extended interface rather than the original `Jimp` interface.

For instance the code block below works fine with this PR:

```js
var img = await jimp.read(body)
		const resizedBody = await img.cover(this.newSize, this.newSize)
			.quality(80)
			.getBufferAsync(this.mimeType);
```