### PR TITLE
Jimp.prototype.write: Option to provide/keep MIME type regardless of file extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,10 +227,10 @@ Online tools are also available to convert TTF fonts to BMFont format (e.g. [Lit
 
 ### Writing to files ###
 
-The image can be written to disk in PNG, JPEG or BMP format (determined by the file extension) using:
+The image can be written to disk in PNG, JPEG or BMP format (determined by either the provided MIME type or the file extension) using:
 
 ```js
-image.write( path, cb ); // Node-style callback will be fired when write is successful
+image.write( path, mime, cb ); // Node-style callback will be fired when write is successful
 ```
 
 The original extension for an image (or "png") can accessed as using `image.getExtension()`. The following will save an image using its original format:
@@ -238,6 +238,12 @@ The original extension for an image (or "png") can accessed as using `image.getE
 ```js
 var file = "new_name." + image.getExtension();
 image.write(file)
+```
+
+The original MIME type can be kept using `Jimp.MIME_ORIGINAL`. The following will save an image with any extension using its original format:
+
+```js
+image.write(path, Jimp.MIME_ORIGINAL)
 ```
 
 ### Writing to Buffers ###
@@ -310,23 +316,23 @@ image.color([
 
 The method supports the following modifiers:
 
-Modifier                | Description
------------------------ | -----------------------
-**lighten** {amount}    | Lighten the color a given amount, from 0 to 100. Providing 100 will always return white (works through [TinyColor](https://github.com/bgrins/TinyColor))
-**brighten** {amount}   | Brighten the color a given amount, from 0 to 100 (works through [TinyColor](https://github.com/bgrins/TinyColor))
-**darken** {amount}     | Darken the color a given amount, from 0 to 100. Providing 100 will always return black (works through [TinyColor](https://github.com/bgrins/TinyColor))
-**desaturate** {amount} | Desaturate the color a given amount, from 0 to 100. Providing 100 will is the same as calling greyscale (works through [TinyColor](https://github.com/bgrins/TinyColor))
-**saturate** {amount}   | Saturate the color a given amount, from 0 to 100 (works through [TinyColor](https://github.com/bgrins/TinyColor))
-**greyscale** {amount}  | Completely desaturates a color into greyscale (works through [TinyColor](https://github.com/bgrins/TinyColor))
-**spin** {degree}       | Spin the hue a given amount, from -360 to 360. Calling with 0, 360, or -360 will do nothing - since it sets the hue back to what it was before. (works through [TinyColor](https://github.com/bgrins/TinyColor))
-**hue** {degree}        | Alias for **spin**
-**mix** {color, amount} | Mixes colors by their RGB component values. Amount is opacity of overlaying color
-**tint** {amount}       | Same as applying **mix** with white color
-**shade** {amount}      | Same as applying **mix** with black color
-**xor** {color}         | Treats the two colors as bitfields and applies an XOR operation to the red, green, and blue components
-**red** {amount}        | Modify Red component by a given amount
-**green** {amount}      | Modify Green component by a given amount
-**blue** {amount}       | Modify Blue component by a given amount
+| Modifier                | Description                                                                                                                                                                                                      |
+| ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **lighten** {amount}    | Lighten the color a given amount, from 0 to 100. Providing 100 will always return white (works through [TinyColor](https://github.com/bgrins/TinyColor))                                                         |
+| **brighten** {amount}   | Brighten the color a given amount, from 0 to 100 (works through [TinyColor](https://github.com/bgrins/TinyColor))                                                                                                |
+| **darken** {amount}     | Darken the color a given amount, from 0 to 100. Providing 100 will always return black (works through [TinyColor](https://github.com/bgrins/TinyColor))                                                          |
+| **desaturate** {amount} | Desaturate the color a given amount, from 0 to 100. Providing 100 will is the same as calling greyscale (works through [TinyColor](https://github.com/bgrins/TinyColor))                                         |
+| **saturate** {amount}   | Saturate the color a given amount, from 0 to 100 (works through [TinyColor](https://github.com/bgrins/TinyColor))                                                                                                |
+| **greyscale** {amount}  | Completely desaturates a color into greyscale (works through [TinyColor](https://github.com/bgrins/TinyColor))                                                                                                   |
+| **spin** {degree}       | Spin the hue a given amount, from -360 to 360. Calling with 0, 360, or -360 will do nothing - since it sets the hue back to what it was before. (works through [TinyColor](https://github.com/bgrins/TinyColor)) |
+| **hue** {degree}        | Alias for **spin**                                                                                                                                                                                               |
+| **mix** {color, amount} | Mixes colors by their RGB component values. Amount is opacity of overlaying color                                                                                                                                |
+| **tint** {amount}       | Same as applying **mix** with white color                                                                                                                                                                        |
+| **shade** {amount}      | Same as applying **mix** with black color                                                                                                                                                                        |
+| **xor** {color}         | Treats the two colors as bitfields and applies an XOR operation to the red, green, and blue components                                                                                                           |
+| **red** {amount}        | Modify Red component by a given amount                                                                                                                                                                           |
+| **green** {amount}      | Modify Green component by a given amount                                                                                                                                                                         |
+| **blue** {amount}       | Modify Blue component by a given amount                                                                                                                                                                          |
 
 ### Convolution matrix ###
 

--- a/README.md
+++ b/README.md
@@ -316,23 +316,23 @@ image.color([
 
 The method supports the following modifiers:
 
-| Modifier                | Description                                                                                                                                                                                                      |
-| ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **lighten** {amount}    | Lighten the color a given amount, from 0 to 100. Providing 100 will always return white (works through [TinyColor](https://github.com/bgrins/TinyColor))                                                         |
-| **brighten** {amount}   | Brighten the color a given amount, from 0 to 100 (works through [TinyColor](https://github.com/bgrins/TinyColor))                                                                                                |
-| **darken** {amount}     | Darken the color a given amount, from 0 to 100. Providing 100 will always return black (works through [TinyColor](https://github.com/bgrins/TinyColor))                                                          |
-| **desaturate** {amount} | Desaturate the color a given amount, from 0 to 100. Providing 100 will is the same as calling greyscale (works through [TinyColor](https://github.com/bgrins/TinyColor))                                         |
-| **saturate** {amount}   | Saturate the color a given amount, from 0 to 100 (works through [TinyColor](https://github.com/bgrins/TinyColor))                                                                                                |
-| **greyscale** {amount}  | Completely desaturates a color into greyscale (works through [TinyColor](https://github.com/bgrins/TinyColor))                                                                                                   |
-| **spin** {degree}       | Spin the hue a given amount, from -360 to 360. Calling with 0, 360, or -360 will do nothing - since it sets the hue back to what it was before. (works through [TinyColor](https://github.com/bgrins/TinyColor)) |
-| **hue** {degree}        | Alias for **spin**                                                                                                                                                                                               |
-| **mix** {color, amount} | Mixes colors by their RGB component values. Amount is opacity of overlaying color                                                                                                                                |
-| **tint** {amount}       | Same as applying **mix** with white color                                                                                                                                                                        |
-| **shade** {amount}      | Same as applying **mix** with black color                                                                                                                                                                        |
-| **xor** {color}         | Treats the two colors as bitfields and applies an XOR operation to the red, green, and blue components                                                                                                           |
-| **red** {amount}        | Modify Red component by a given amount                                                                                                                                                                           |
-| **green** {amount}      | Modify Green component by a given amount                                                                                                                                                                         |
-| **blue** {amount}       | Modify Blue component by a given amount                                                                                                                                                                          |
+Modifier                | Description
+----------------------- | -----------------------
+**lighten** {amount}    | Lighten the color a given amount, from 0 to 100. Providing 100 will always return white (works through [TinyColor](https://github.com/bgrins/TinyColor))
+**brighten** {amount}   | Brighten the color a given amount, from 0 to 100 (works through [TinyColor](https://github.com/bgrins/TinyColor))
+**darken** {amount}     | Darken the color a given amount, from 0 to 100. Providing 100 will always return black (works through [TinyColor](https://github.com/bgrins/TinyColor))
+**desaturate** {amount} | Desaturate the color a given amount, from 0 to 100. Providing 100 will is the same as calling greyscale (works through [TinyColor](https://github.com/bgrins/TinyColor))
+**saturate** {amount}   | Saturate the color a given amount, from 0 to 100 (works through [TinyColor](https://github.com/bgrins/TinyColor))
+**greyscale** {amount}  | Completely desaturates a color into greyscale (works through [TinyColor](https://github.com/bgrins/TinyColor))
+**spin** {degree}       | Spin the hue a given amount, from -360 to 360. Calling with 0, 360, or -360 will do nothing - since it sets the hue back to what it was before. (works through [TinyColor](https://github.com/bgrins/TinyColor))
+**hue** {degree}        | Alias for **spin**
+**mix** {color, amount} | Mixes colors by their RGB component values. Amount is opacity of overlaying color
+**tint** {amount}       | Same as applying **mix** with white color
+**shade** {amount}      | Same as applying **mix** with black color
+**xor** {color}         | Treats the two colors as bitfields and applies an XOR operation to the red, green, and blue components
+**red** {amount}        | Modify Red component by a given amount
+**green** {amount}      | Modify Green component by a given amount
+**blue** {amount}       | Modify Blue component by a given amount                                                                                                                                                                        |
 
 ### Convolution matrix ###
 

--- a/index.js
+++ b/index.js
@@ -2767,21 +2767,31 @@ function measureTextHeight (font, text, maxWidth) {
 /**
  * Writes the image to a file
  * @param path a path to the destination file (either PNG or JPEG)
+ * @param (optional) mime the MIME type of the saved file (can be Jimp.MIME_ORIGINAL to keep the original MIME type)
  * @param (optional) cb a function to call when the image is saved to disk
  * @returns this for chaining of methods
  */
-Jimp.prototype.write = function (path, cb) {
+Jimp.prototype.write = function (path, mime, cb) {
     if (!FS || !FS.createWriteStream) {
         throw Error('Cant access the filesystem. You can use the getBase64 method.');
     }
     if (typeof path !== "string")
         return throwError.call(this, "path must be a string", cb);
+    if (typeof mime === "function" && typeof cb === "undefined") {
+        cb = mime;
+        mime = null;
+    }
     if (typeof cb === "undefined") cb = function () {};
     if (typeof cb !== "function")
         return throwError.call(this, "cb must be a function", cb);
 
     var that = this;
-    var mime = MIME.lookup(path);
+    if (!mime) {
+        mime = MIME.lookup(path);
+    }
+    if (mime === Jimp.MIME_ORIGINAL) {
+        mime = this.getMIME();
+    }
 
     var pathObj = Path.parse(path);
     if (pathObj.dir) MkDirP.sync(pathObj.dir);

--- a/index.js
+++ b/index.js
@@ -469,6 +469,7 @@ Jimp.MIME_JGD = "image/jgd";
 Jimp.MIME_BMP = "image/bmp";
 Jimp.MIME_X_MS_BMP = "image/x-ms-bmp";
 Jimp.MIME_GIF = "image/gif";
+Jimp.MIME_ORIGINAL = "originalMimeType";
 
 // PNG filter types
 Jimp.PNG_FILTER_AUTO = -1;

--- a/jimp.d.ts
+++ b/jimp.d.ts
@@ -78,7 +78,7 @@ declare namespace Jimp {
         dither16(cb?: Jimp.ImageCallback): this;
         color(actions: any, cb?: Jimp.ImageCallback): this;
         colour(actions: any, cb?: Jimp.ImageCallback): this;
-        write(path: string, cb?: Jimp.ImageCallback): this;
+        write(path: string, mime?: string, cb?: Jimp.ImageCallback): this;
         print(font: any, x: number, y: number, text: string, maxWidth?: number | Jimp.ImageCallback, maxHeight?: number | Jimp.ImageCallback, cb?: Jimp.ImageCallback): this;
         inspect(): string;
         toString(): string;
@@ -93,6 +93,7 @@ declare namespace Jimp {
         static MIME_BMP: string;
         static MIME_X_MS_BMP: string;
         static MIME_GIF: string;
+        static MIME_ORIGINAL: string;
         // PNG filter types
         static PNG_FILTER_AUTO: number;
         static PNG_FILTER_NONE: number;


### PR DESCRIPTION
I use Jimp to resize uploaded images and want temporary files to have no extension in order to make maintenance and deletion easier. For that reason, I needed Jimp to be capable of accepting an optional MIME type parameter in the `write` method.

Use of the augmented method is documented.
Since there were no tests for the write method and I wasn't sure how to handle functional tests including the file system, I didn't write any.
I didn't update the version number.