### PR TITLE
Generate and ts constructor fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,6 +436,18 @@ var image = new Jimp(256, 256, 0xFF0000FF, function (err, image) {
 });
 ```
 
+The same can be achieved by calling the static `generate` function:
+
+```js
+var image = Jimp.generate(256, 256, function(err, image) {
+    // this image is 256 x 256, every pixel is set to 0x00000000
+});
+
+var red = Jimp.generate(256, 256, 0xFF0000FF, function(err, image) {
+    // this image is 256 x 256, every pixel is set to 0xFF0000FF
+});
+```
+
 ## Comparing images ##
 
 To generate a [perceptual hash](https://en.wikipedia.org/wiki/Perceptual_hashing) of a Jimp image, based on the [pHash](http://phash.org/) algorithm, use:

--- a/index.js
+++ b/index.js
@@ -311,7 +311,7 @@ Jimp.appendConstructorOption = function (name, test, runner) {
  * @param (optional) cb a function to call when the image is parsed to a bitmap
  * @returns An instance of Jimp wrapping the new image
  */
-Jimp.generate = function create(w, h, color, cb) {
+Jimp.generate = function generate (w, h, color, cb) {
     if (typeof color === "function" && typeof cb === "undefined") {
         cb = color;
         return new Jimp(w, h, cb);

--- a/index.js
+++ b/index.js
@@ -304,6 +304,23 @@ Jimp.appendConstructorOption = function (name, test, runner) {
 }
 
 /**
+ * Generate a new image
+ * @param w the width of the image
+ * @param h the height of the image
+ * @param color (optional) the pixel color
+ * @param (optional) cb a function to call when the image is parsed to a bitmap
+ * @returns An instance of Jimp wrapping the new image
+ */
+Jimp.generate = function create(w, h, color, cb) {
+    if (typeof color === "function" && typeof cb === "undefined") {
+        cb = color;
+        return new Jimp(w, h, cb);
+    }
+
+    return new Jimp(w, h, color, cb);
+}
+
+/**
  * Emit for multiple listeners
  */
 Jimp.prototype.emitMulti = function emitMulti (methodName, eventName, data={}) {

--- a/jimp.d.ts
+++ b/jimp.d.ts
@@ -18,13 +18,13 @@ declare namespace Jimp {
     }
 
     class Jimp {
-        bitmap: Bitmap;
-
         constructor(path: string, cb?: Jimp.ImageCallback);
         constructor(image: Jimp, cb?: Jimp.ImageCallback);
         constructor(data: Buffer, cb?: Jimp.ImageCallback);
         constructor(w: number, h: number, cb?: Jimp.ImageCallback);
         constructor(w: number, h: number, background?: number, cb?: Jimp.ImageCallback);
+        
+        bitmap: Bitmap;
 
         clone(cb?: Jimp.ImageCallback): Jimp;
         quality(n: number, cb?: Jimp.ImageCallback): this;
@@ -138,13 +138,8 @@ declare namespace Jimp {
         static EDGE_WRAP: number;
         static EDGE_CROP: number;
 
-        /* These are constructors, have already moved up, TODO: remove it in the future
-        (path: string, cb?: Jimp.ImageCallback): void;
-        (image: Jimp, cb?: Jimp.ImageCallback): void;
-        (data: Buffer, cb?: Jimp.ImageCallback): void;
-        (w: number, h: number, cb?: Jimp.ImageCallback): void;
-        (w: number, h: number, background?: number, cb?: Jimp.ImageCallback): void;
-        */
+        static generate(w: number, h: number, cb?: Jimp.ImageCallback): Jimp;
+        static generate(w: number, h: number, background?: number, cb?: Jimp.ImageCallback): Jimp;
 
         static read(src: string | Buffer, cb?: Jimp.ImageCallback): Promise<Jimp>;
         static loadFont(file: string, cb?: Jimp.ImageCallback): Promise<any>;


### PR DESCRIPTION
Some people (myself included) had some issues with TypeScript and the constructor to generate a new image.
Moving the constructors to the top of their class should fix that problem.

And since it fits the pattern for the other use cases of Jimp, I added a static `generate` function that creates a new image. That way it can be used the same as, say, read to create a Jimp instance.

fixes #393  