### PR TITLE
fix 'write' and 'getBuffer' chaining

### DIFF
--- a/index.js
+++ b/index.js
@@ -502,7 +502,8 @@ function parseBitmap(data, path, cb) {
                     width: data.width,
                     height: data.height
                 };
-                return cb.call(this, null, this);
+
+                cb.call(this, null, this);
             });
             break;
         }
@@ -517,37 +518,44 @@ function parseBitmap(data, path, cb) {
                 } catch (err) {
                     /* meh */
                 }
-                return cb.call(this, null, this);
+                cb.call(this, null, this);
             } catch (err) {
-                return cb.call(this, err, this);
+                cb.call(this, err, this);
             }
+            break;
 
         case Jimp.MIME_TIFF: {
-            var ifds = UTIF.decode(data);
-            var page = ifds[0];
+            const ifds = UTIF.decode(data);
+            const page = ifds[0];
             UTIF.decodeImages(data, ifds);
-            var rgba = UTIF.toRGBA8(page);
+            const rgba = UTIF.toRGBA8(page);
+
             this.bitmap = {
-                data: new Buffer(rgba),
+                data: Buffer.from(rgba),
                 width: page.t256[0],
                 height: page.t257[0]
             };
 
-            return cb.call(this, null, this);
+            cb.call(this, null, this);
+            break;
         }
 
         case Jimp.MIME_BMP:
         case Jimp.MIME_X_MS_BMP:
             this.bitmap = BMP.decode(data);
-            return cb.call(this, null, this);
+            cb.call(this, null, this);
+            break;
 
         case Jimp.MIME_GIF:
             this.bitmap = getBitmapFromGIF(data);
-            return cb.call(this, null, this);
+            cb.call(this, null, this);
+            break;
 
         default:
             return throwError.call(this, 'Unsupported MIME type: ' + mime, cb);
     }
+
+    return this;
 }
 
 /*
@@ -3722,7 +3730,8 @@ Jimp.prototype.getBuffer = function(mime, cb) {
             }
 
             const buffer = PNG.sync.write(png);
-            return cb.call(this, null, buffer);
+            cb.call(this, null, buffer);
+            break;
         }
 
         case Jimp.MIME_JPEG: {
@@ -3731,24 +3740,28 @@ Jimp.prototype.getBuffer = function(mime, cb) {
                 compositeBitmapOverBackground(this),
                 this._quality
             );
-            return cb.call(this, null, jpeg.data);
+            cb.call(this, null, jpeg.data);
+            break;
         }
 
         case Jimp.MIME_BMP:
         case Jimp.MIME_X_MS_BMP: {
             // composite onto a new image so that the background shows through alpha channels
             const bmp = BMP.encode(compositeBitmapOverBackground(this));
-            return cb.call(this, null, bmp.data);
+            cb.call(this, null, bmp.data);
+            break;
         }
 
         case Jimp.MIME_TIFF: {
             const c = compositeBitmapOverBackground(this);
             const tiff = UTIF.encodeImage(c.data, c.width, c.height);
-            return cb.call(this, null, Buffer.from(tiff));
+            cb.call(this, null, Buffer.from(tiff));
+            break;
         }
 
         default:
-            return cb.call(this, 'Unsupported MIME type: ' + mime);
+            cb.call(this, 'Unsupported MIME type: ' + mime);
+            break;
     }
 
     return this;


### PR DESCRIPTION
returning in the switch was breaking the ability to chain calls after calling 'write' or 'getBuffer'