### PR TITLE
Promisify Functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@ The image can be written to disk in PNG, JPEG or BMP format (determined by the f
 
 ```js
 image.write(path, cb); // Node-style callback will be fired when write is successful
+image.writeAsync(path); // Returns Promise
 ```
 
 The original extension for an image (or "png") can accessed as using `image.getExtension()`. The following will save an image using its original format:
@@ -286,6 +287,7 @@ A PNG, JPEG or BMP binary Buffer of an image (e.g. for storage in a database) ca
 
 ```js
 image.getBuffer(mime, cb); // Node-style callback will be fired with result
+image.getBufferAsync(mime); // Returns Promise
 ```
 
 For convenience, supported MIME types are available as static properties:
@@ -304,6 +306,7 @@ A Base64 data URI can be generated in the same way as a Buffer, using:
 
 ```js
 image.getBase64(mime, cb); // Node-style callback will be fired with result
+image.getBase64Async(mime); // Returns Promise
 ```
 
 ### PNG and JPEG quality

--- a/jimp.d.ts
+++ b/jimp.d.ts
@@ -181,12 +181,15 @@ declare namespace Jimp {
         exifRotate(): this;
         displace(map: Jimp, offset: number, cb?: Jimp.ImageCallback): this;
         getBuffer(mime: string, cb: (err: Error, buffer: Buffer) => any): this;
+        getBufferAsync(mime: string): Promise<Jimp>;
         getBase64(mime: string, cb?: (err: Error, src: string) => any): this;
+        getBase64Async(mime: string): Promise<Jimp>;
         dither565(cb?: Jimp.ImageCallback): this;
         dither16(cb?: Jimp.ImageCallback): this;
         color(actions: any, cb?: Jimp.ImageCallback): this;
         colour(actions: any, cb?: Jimp.ImageCallback): this;
         write(path: string, cb?: Jimp.ImageCallback): this;
+        writeAsync(path: string): Promise<Jimp>;
         print(
             font: any,
             x: number,

--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,7 @@ import * as shape from './image-manipulation/shape';
 import * as color from './image-manipulation/color';
 import * as effects from './image-manipulation/effects';
 
+import promisify from './utils/promisify';
 import isDef from './utils/is-def';
 import { clear } from './utils/log';
 import { parseBitmap, getBuffer, getBufferAsync } from './utils/image-bitmap';
@@ -433,17 +434,7 @@ class Jimp extends EventEmitter {
         return this;
     }
 
-    writeAsync(path) {
-        return new Promise((resolve, reject) =>
-            this.write(path, err => {
-                if (err) {
-                    return reject(err);
-                }
-
-                resolve(this);
-            })
-        );
-    }
+    writeAsync = path => promisify(this.write, this, path);
 
     /**
      * Sets the deflate level used when saving as PNG format (default is 9)
@@ -601,17 +592,7 @@ class Jimp extends EventEmitter {
         return this;
     }
 
-    getBase64Async(mime) {
-        return new Promise((resolve, reject) =>
-            this.getBase64(mime, err => {
-                if (err) {
-                    return reject(err);
-                }
-
-                resolve(this);
-            })
-        );
-    }
+    getBase64Async = mime => promisify(this.getBase64, this, mime);
 
     /**
      * Generates a perceptual hash of the image <https://en.wikipedia.org/wiki/Perceptual_hashing>.

--- a/src/utils/image-bitmap.js
+++ b/src/utils/image-bitmap.js
@@ -10,6 +10,7 @@ import GIF from 'omggif';
 
 import * as constants from '../constants';
 import { throwError } from './error-checking';
+import promisify from './promisify';
 
 function getMIMEFromBuffer(buffer, path) {
     const fileTypeFromBuffer = fileType(buffer);
@@ -253,13 +254,5 @@ export function getBuffer(mime, cb) {
 }
 
 export function getBufferAsync(mime) {
-    return new Promise((resolve, reject) =>
-        getBuffer(mime, err => {
-            if (err) {
-                return reject(err);
-            }
-
-            resolve(this);
-        })
-    );
+    return promisify(getBuffer, this, mime);
 }

--- a/src/utils/image-bitmap.js
+++ b/src/utils/image-bitmap.js
@@ -169,74 +169,10 @@ function compositeBitmapOverBackground(Jimp, image) {
     ).composite(image, 0, 0).bitmap;
 }
 
-function getBufferFromImage(image, mime) {
-    let buffer;
-
-    switch (mime.toLowerCase()) {
-        case constants.MIME_PNG: {
-            const png = new PNG({
-                width: image.bitmap.width,
-                height: image.bitmap.height,
-                bitDepth: 8,
-                deflateLevel: image._deflateLevel,
-                deflateStrategy: image._deflateStrategy,
-                filterType: image._filterType,
-                colorType: image._rgba ? 6 : 2,
-                inputHasAlpha: true
-            });
-
-            if (image._rgba) {
-                png.data = Buffer.from(image.bitmap.data);
-            } else {
-                // when PNG doesn't support alpha
-                png.data = compositeBitmapOverBackground(
-                    image.constructor,
-                    image
-                ).data;
-            }
-
-            buffer = PNG.sync.write(png);
-            break;
-        }
-
-        case constants.MIME_JPEG: {
-            // composite onto a new image so that the background shows through alpha channels
-            const jpeg = JPEG.encode(
-                compositeBitmapOverBackground(image.constructor, image),
-                image._quality
-            );
-            buffer = jpeg.data;
-            break;
-        }
-
-        case constants.MIME_BMP:
-        case constants.MIME_X_MS_BMP: {
-            // composite onto a new image so that the background shows through alpha channels
-            const bmp = BMP.encode(
-                compositeBitmapOverBackground(image.constructor, image)
-            );
-            buffer = bmp.data;
-            break;
-        }
-
-        case constants.MIME_TIFF: {
-            const c = compositeBitmapOverBackground(image.constructor, image);
-            const tiff = UTIF.encodeImage(c.data, c.width, c.height);
-            buffer = Buffer.from(tiff);
-            break;
-        }
-
-        default:
-            throw new TypeError('Unsupported MIME type: ' + mime);
-    }
-
-    return buffer;
-}
-
 /**
  * Converts the image to a buffer
  * @param {string} mime the mime type of the image buffer to be created
- * @param {function(Error, Jimp)} cb (optional) a function to call when the  is saved to disk
+ * @param {function(Error, Jimp)} cb a Node-style function to call with the buffer as the second argument
  * @returns {Jimp} this for chaining of methods
  */
 export function getBuffer(mime, cb) {
@@ -249,34 +185,81 @@ export function getBuffer(mime, cb) {
         return throwError.call(this, 'mime must be a string', cb);
     }
 
-    if (typeof cb !== 'function' && typeof cb !== 'string') {
+    if (typeof cb !== 'function') {
         return throwError.call(this, 'cb must be a function', cb);
     }
 
-    try {
-        const buffer = getBufferFromImage(this, mime);
-        cb.call(this, null, buffer);
-    } catch (error) {
-        return throwError.call(this, error, cb);
+    switch (mime.toLowerCase()) {
+        case constants.MIME_PNG: {
+            const png = new PNG({
+                width: this.bitmap.width,
+                height: this.bitmap.height,
+                bitDepth: 8,
+                deflateLevel: this._deflateLevel,
+                deflateStrategy: this._deflateStrategy,
+                filterType: this._filterType,
+                colorType: this._rgba ? 6 : 2,
+                inputHasAlpha: true
+            });
+
+            if (this._rgba) {
+                png.data = Buffer.from(this.bitmap.data);
+            } else {
+                // when PNG doesn't support alpha
+                png.data = compositeBitmapOverBackground(
+                    this.constructor,
+                    this
+                ).data;
+            }
+
+            const buffer = PNG.sync.write(png);
+            cb.call(this, null, buffer);
+            break;
+        }
+
+        case constants.MIME_JPEG: {
+            // composite onto a new image so that the background shows through alpha channels
+            const jpeg = JPEG.encode(
+                compositeBitmapOverBackground(this.constructor, this),
+                this._quality
+            );
+            cb.call(this, null, jpeg.data);
+            break;
+        }
+
+        case constants.MIME_BMP:
+        case constants.MIME_X_MS_BMP: {
+            // composite onto a new image so that the background shows through alpha channels
+            const bmp = BMP.encode(
+                compositeBitmapOverBackground(this.constructor, this)
+            );
+            cb.call(this, null, bmp.data);
+            break;
+        }
+
+        case constants.MIME_TIFF: {
+            const c = compositeBitmapOverBackground(this.constructor, this);
+            const tiff = UTIF.encodeImage(c.data, c.width, c.height);
+            cb.call(this, null, Buffer.from(tiff));
+            break;
+        }
+
+        default:
+            cb.call(this, 'Unsupported MIME type: ' + mime);
+            break;
     }
 
     return this;
 }
 
 export function getBufferAsync(mime) {
-    if (mime === constants.AUTO) {
-        // allow auto MIME detection
-        mime = this.getMIME();
-    }
+    return new Promise((resolve, reject) =>
+        getBuffer(mime, err => {
+            if (err) {
+                return reject(err);
+            }
 
-    if (typeof mime !== 'string') {
-        throw new TypeError('mime must be a string');
-    }
-
-    try {
-        const buffer = getBufferFromImage(this, mime);
-        return Promise.resolve(buffer);
-    } catch (error) {
-        return Promise.reject(error);
-    }
+            resolve(this);
+        })
+    );
 }

--- a/src/utils/promisify.js
+++ b/src/utils/promisify.js
@@ -1,0 +1,13 @@
+const promisify = (fun, ctx, ...args) =>
+    new Promise((resolve, reject) => {
+        args.push((err, data) => {
+            if (err) {
+                reject(err);
+            }
+
+            resolve(data);
+        });
+        fun.bind(ctx)(...args);
+    });
+
+export default promisify;

--- a/test/async.test.js
+++ b/test/async.test.js
@@ -4,7 +4,7 @@ const { Jimp, getTestDir } = require('./test-helper');
 
 const imagesDir = getTestDir() + '/samples';
 
-describe.only('Async functions', () => {
+describe('Async functions', () => {
     it('write returns promise', done => {
         const writePath = './test.png';
 
@@ -17,7 +17,7 @@ describe.only('Async functions', () => {
         new Jimp(imagesDir + '/dice.png', function(err) {
             if (err) done(err);
 
-            this.write(writePath, 'async').then(image => {
+            this.writeAsync(writePath).then(image => {
                 should.exist(image);
                 fs.existsSync(writePath).should.be.true();
                 fs.unlinkSync(writePath);
@@ -33,8 +33,7 @@ describe.only('Async functions', () => {
 
         new Jimp(imagesDir + '/dice.png', function(err) {
             if (err) done(err);
-
-            this.getBuffer(Jimp.AUTO, 'async').then(buffer => {
+            this.getBufferAsync(Jimp.AUTO).then(buffer => {
                 should.exist(buffer);
                 done();
             });
@@ -49,7 +48,7 @@ describe.only('Async functions', () => {
         new Jimp(imagesDir + '/dice.png', function(err) {
             if (err) done(err);
 
-            this.getBase64(Jimp.AUTO, 'async').then(buffer => {
+            this.getBase64Async(Jimp.AUTO).then(buffer => {
                 should.exist(buffer);
                 done();
             });

--- a/test/async.test.js
+++ b/test/async.test.js
@@ -25,4 +25,19 @@ describe.only('Async functions', () => {
             });
         });
     });
+
+    it('getBuffer returns promise', done => {
+        if (process.env.BABEL_ENV === undefined) {
+            return done();
+        }
+
+        new Jimp(imagesDir + '/dice.png', function(err) {
+            if (err) done(err);
+
+            this.getBuffer(Jimp.AUTO, 'async').then(buffer => {
+                should.exist(buffer);
+                done();
+            });
+        });
+    });
 });

--- a/test/async.test.js
+++ b/test/async.test.js
@@ -40,4 +40,19 @@ describe.only('Async functions', () => {
             });
         });
     });
+
+    it('getBase64 returns promise', done => {
+        if (process.env.BABEL_ENV === undefined) {
+            return done();
+        }
+
+        new Jimp(imagesDir + '/dice.png', function(err) {
+            if (err) done(err);
+
+            this.getBase64(Jimp.AUTO, 'async').then(buffer => {
+                should.exist(buffer);
+                done();
+            });
+        });
+    });
 });

--- a/test/async.test.js
+++ b/test/async.test.js
@@ -1,0 +1,28 @@
+const fs = require('fs');
+const should = require('should');
+const { Jimp, getTestDir } = require('./test-helper');
+
+const imagesDir = getTestDir() + '/samples';
+
+describe.only('Async functions', () => {
+    it('write returns promise', done => {
+        const writePath = './test.png';
+
+        // process.env is undefined in the browser tests. If BABEL_ENV
+        // isn't found don't run this test in the browser
+        if (process.env.BABEL_ENV === undefined) {
+            return done();
+        }
+
+        new Jimp(imagesDir + '/dice.png', function(err) {
+            if (err) done(err);
+
+            this.write(writePath, 'async').then(image => {
+                should.exist(image);
+                fs.existsSync(writePath).should.be.true();
+                fs.unlinkSync(writePath);
+                done();
+            });
+        });
+    });
+});


### PR DESCRIPTION
closes #232 - write now can return a promise
closes #90 - same as above and getBuffer can now be async
closes #374 - base64 can now be async
closes #308 closes #445 - Jimp.read can take all args that the constructor can. Jimp.create added for clearer syntax. No need to add promises to the jimp constructor.
