### PR TITLE
Fix Build

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "prettier": "^1.13.7",
     "should": "^13.2.1",
     "source-map-support": "^0.5.6",
+    "tfilter": "^1.0.1",
     "uglify-js": "^3.4.5",
     "xo": "^0.21.1"
   },

--- a/tools/browser-build.js
+++ b/tools/browser-build.js
@@ -6,6 +6,7 @@ const envify = require('envify/custom');
 const UglifyJS = require('uglify-js');
 const browserify = require('browserify');
 const babelify = require('babelify');
+const tfilter = require('tfilter');
 
 function debug(...args) {
     if (process.env.DEBUG) {
@@ -57,6 +58,10 @@ function bundle(files, config, callback) {
 
     bundler
         .transform(babelify)
+        .transform(
+            tfilter(babelify, { include: '**/node_modules/file-type/*.js' }),
+            { presets: ['@babel/env'], global: true }
+        )
         .transform(envify({ ENVIRONMENT: 'BROWSER' }))
         .bundle((err, baseCode) => {
             if (err) return callback(err);

--- a/yarn.lock
+++ b/yarn.lock
@@ -6166,6 +6166,10 @@ sha.js@^2.4.0, sha.js@^2.4.8, sha.js@~2.4.4:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
 
+shallow-copy@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/shallow-copy/-/shallow-copy-0.0.1.tgz#415f42702d73d810330292cc5ee86eae1a11a170"
+
 shasum@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/shasum/-/shasum-1.0.2.tgz#e7012310d8f417f4deb5712150e5678b87ae565f"
@@ -6711,6 +6715,15 @@ test-exclude@^4.2.0, test-exclude@^4.2.1:
 text-table@~0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
+
+tfilter@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/tfilter/-/tfilter-1.0.1.tgz#3dce264f16040021c6a0be304e26bc6e191cb673"
+  dependencies:
+    defined "^1.0.0"
+    minimatch "^3.0.4"
+    resolve "^1.5.0"
+    shallow-copy "0.0.1"
 
 the-argv@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
have to babel es6 modules because babelify wont. tfilter targets the specific file

only offending module is `file-type`

Before this PR:
* `const` was included in `browser/lib/jimp.js` (bad)
* minified build wasn't working at all because of above `const`. Bad!