### PR TITLE
Fix type declarations

### DIFF
--- a/jimp.d.ts
+++ b/jimp.d.ts
@@ -269,8 +269,8 @@ declare namespace Jimp {
 
         static appendConstructorOption(
             name: string,
-            test: function,
-            run: function
+            test: Function,
+            run: Function
         );
 
         static read(path: string): Promise<Jimp>;


### PR DESCRIPTION
tsc complains 
```ts
node_modules/jimp/jimp.d.ts:270:19 - error TS2304: Cannot find name 'function'.

270             test: function,
                      ~~~~~~~~

node_modules/jimp/jimp.d.ts:271:18 - error TS2304: Cannot find name 'function'.

271             run: function
                     ~~~~~~~~

```