### PR TITLE
polyfill es6 and es7 features for older versions of node

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -2,7 +2,14 @@ module.exports = api => {
     api.cache(true);
 
     return {
-        presets: ['@babel/env'],
+        presets: [
+            [
+                '@babel/preset-env',
+                {
+                    useBuiltIns: 'usage'
+                }
+            ]
+        ],
 
         plugins: [
             '@babel/proposal-class-properties',


### PR DESCRIPTION
# What's Changing and Why

`Object.entries` is not available in node <6.4.0 so we can polyfill it.

closes #526

## What else might be affected

File size

## Tasks

-   [x] Add tests
-   [x] Update Documentation
-   [x] Update `jimp.d.ts`
