### PR TITLE
fix cover function without alignBits

### DIFF
--- a/src/image-manipulation/shape.js
+++ b/src/image-manipulation/shape.js
@@ -359,7 +359,8 @@ export function cover(w, h, alignBits, mode, cb) {
     }
 
     alignBits =
-        alignBits || this.HORIZONTAL_ALIGN_CENTER | this.VERTICAL_ALIGN_MIDDLE;
+        alignBits ||
+        constants.HORIZONTAL_ALIGN_CENTER | constants.VERTICAL_ALIGN_MIDDLE;
     const hbits = alignBits & ((1 << 3) - 1);
     const vbits = alignBits >> 3;
 


### PR DESCRIPTION
# What's Changing and Why
fix cover function without alignBits
- Error: only use one flag per alignment direction

## What else might be affected

## Tasks

-   [ ] Add tests
-   [ ] Update Documentation
-   [ ] Update `jimp.d.ts`
-   [ ] Add [SemVer](https://semver.org/) Label
