### PR TITLE
Can now create a new jimp with the CSS hex color format

### DIFF
--- a/README.md
+++ b/README.md
@@ -504,7 +504,7 @@ Jimp.rgbaToInt(r, g, b, a); // e.g. converts 255, 255, 255, 255 to 0xFFFFFFFF
 Jimp.intToRGBA(hex); // e.g. converts 0xFFFFFFFF to {r: 255, g: 255, b: 255, a:255}
 ```
 
-You can convert a css hex color to its true rgba hexadecimal equivalent:
+You can convert a css color (Hex, RGB, RGBA, HSL, HSLA, HSV, HSVA, Named) to its hexadecimal equivalent:
 
 ```js
 Jimp.cssColorToHex(cssColor); // e.g. converts #FF00FF to 0xFF00FFFF
@@ -528,7 +528,7 @@ new Jimp(256, 256, 0xff0000ff, function(err, image) {
 });
 ```
 
-Or you can use the css hex color format:
+Or you can use a css color format:
 
 ```js
 new Jimp(256, 256, '#FF00FF', function(err, image) {

--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ Jimp.loadFont(Jimp.FONT_SANS_32_BLACK).then(function(font) {
 });
 ```
 
-Online tools are also available to convert TTF fonts to BMFont format. They can be used to create color font or sprite packs.  
+Online tools are also available to convert TTF fonts to BMFont format. They can be used to create color font or sprite packs.
 
 :star: [Littera](http://kvazars.com/littera/)
 
@@ -504,6 +504,12 @@ Jimp.rgbaToInt(r, g, b, a); // e.g. converts 255, 255, 255, 255 to 0xFFFFFFFF
 Jimp.intToRGBA(hex); // e.g. converts 0xFFFFFFFF to {r: 255, g: 255, b: 255, a:255}
 ```
 
+You can convert a css hex color to its true rgba hexadecimal equivalent:
+
+```js
+Jimp.cssColorToHex(cssColor); // e.g. converts #FF00FF to 0xFF00FFFF
+```
+
 ### Creating new images
 
 If you want to begin with an empty Jimp image, you can call the Jimp constructor passing the width and height of the image to create and a Node-style callback:
@@ -519,6 +525,14 @@ You can optionally set the pixel colour as follows:
 ```js
 new Jimp(256, 256, 0xff0000ff, function(err, image) {
     // this image is 256 x 256, every pixel is set to 0xFF0000FF
+});
+```
+
+Or you can use the css hex color format:
+
+```js
+new Jimp(256, 256, '#FF00FF', function(err, image) {
+    // this image is 256 x 256, every pixel is set to #FF00FF
 });
 ```
 

--- a/jimp.d.ts
+++ b/jimp.d.ts
@@ -220,6 +220,12 @@ declare namespace Jimp {
             background?: number,
             cb?: Jimp.ImageCallback
         );
+        constructor(
+            w: number,
+            h: number,
+            background?: string,
+            cb?: Jimp.ImageCallback
+        );
         // For custom constructors when using Jimp.appendConstructorOption
         constructor(...args: any[]);
 
@@ -522,6 +528,7 @@ declare namespace Jimp {
             cb: GenericCallback<number, any, Jimp>
         ): number;
         static intToRGBA(i: number, cb?: GenericCallback<Jimp.RGBA>): Jimp.RGBA;
+        static cssColorToHex(cssColor: string): number;
         static limit255(n: number): number;
         static diff(
             img1: Jimp,

--- a/src/index.js
+++ b/src/index.js
@@ -236,11 +236,13 @@ class Jimp extends EventEmitter {
             const h = parseInt(args[1], 10);
             cb = args[2];
 
+            // with a hex color
             if (typeof args[2] === 'number') {
                 this._background = args[2];
                 cb = args[3];
             }
 
+            // with a css color
             if (typeof args[2] === 'string') {
                 this._background = Jimp.cssColorToHex(args[2]);
                 cb = args[3];

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ import anyBase from 'any-base';
 import bMFont from 'load-bmfont';
 import MkDirP from 'mkdirp';
 import pixelMatch from 'pixelmatch';
+import tinyColor from 'tinycolor2';
 
 import ImagePHash from './modules/phash';
 import request from './request';
@@ -237,6 +238,11 @@ class Jimp extends EventEmitter {
 
             if (typeof args[2] === 'number') {
                 this._background = args[2];
+                cb = args[3];
+            }
+
+            if (typeof args[2] === 'string') {
+                this._background = Jimp.cssColorToHex(args[2]);
                 cb = args[3];
             }
 
@@ -973,6 +979,20 @@ Jimp.intToRGBA = function(i, cb) {
 };
 
 /**
+ * Converts a css color (#FFFFFF) to a hex number
+ * @param {string} cssColor a number
+ * @returns {number} a hex number representing a color
+ */
+Jimp.cssColorToHex = function(cssColor) {
+    cssColor = cssColor || 0; // 0, null, undefined, NaN
+
+    if (typeof cssColor === 'number') return Number(cssColor);
+
+    const color = new tinyColor(cssColor);
+    return parseInt(color.toHex8(), 16);
+};
+
+/**
  * Limits a number to between 0 or 255
  * @param {number} n a number
  * @returns {number} the number limited to between 0 or 255
@@ -1128,8 +1148,7 @@ Jimp.loadFont = function(file, cb) {
                 kernings[firstString] = kernings[firstString] || {};
                 kernings[firstString][
                     String.fromCharCode(font.kernings[i].second)
-                ] =
-                    font.kernings[i].amount;
+                ] = font.kernings[i].amount;
             }
 
             loadPages(Path.dirname(file), font.pages).then(pages => {

--- a/src/index.js
+++ b/src/index.js
@@ -981,7 +981,7 @@ Jimp.intToRGBA = function(i, cb) {
 };
 
 /**
- * Converts a css color (#FFFFFF) to a hex number
+ * Converts a css color (Hex, 8-digit (RGBA) Hex, RGB, RGBA, HSL, HSLA, HSV, HSVA, Named) to a hex number
  * @param {string} cssColor a number
  * @returns {number} a hex number representing a color
  */
@@ -990,8 +990,7 @@ Jimp.cssColorToHex = function(cssColor) {
 
     if (typeof cssColor === 'number') return Number(cssColor);
 
-    const color = new tinyColor(cssColor);
-    return parseInt(color.toHex8(), 16);
+    return parseInt(tinyColor(cssColor).toHex8(), 16);
 };
 
 /**

--- a/test/events.test.js
+++ b/test/events.test.js
@@ -30,13 +30,45 @@ describe('Events', () => {
                 .on('error', done);
         });
 
-        it('initializes with a css color', done => {
-            new Jimp(2, 2, '#FFFFFF')
-                .on('initialized', function() {
-                    this.getPixelColor(1, 1).should.be.equal(0xffffffff);
-                    done();
-                })
-                .on('error', done);
+        // (Hex, RGB, RGBA, HSL, HSLA, HSV, HSVA, Named)
+        it('initializes with a css color (Hex)', async () => {
+            const image = await Jimp.create(2, 2, '#FFFFFF');
+            image.getPixelColor(1, 1).should.be.equal(0xffffffff);
+        });
+
+        it('initializes with a css color (RGB)', async () => {
+            const image = await Jimp.create(2, 2, 'rgb (255, 255, 255)');
+            image.getPixelColor(1, 1).should.be.equal(0xffffffff);
+        });
+
+        it('initializes with a css color (RGBA)', async () => {
+            const image = await Jimp.create(2, 2, 'rgba (255, 255, 255, 1)');
+            image.getPixelColor(1, 1).should.be.equal(0xffffffff);
+        });
+
+        it('initializes with a css color (HSL)', async () => {
+            const image = await Jimp.create(2, 2, 'hsl (100%, 100%, 100%)');
+            image.getPixelColor(1, 1).should.be.equal(0xffffffff);
+        });
+
+        it('initializes with a css color (HSLA)', async () => {
+            const image = await Jimp.create(2, 2, 'hsla (100%, 100%, 100%, 1)');
+            image.getPixelColor(1, 1).should.be.equal(0xffffffff);
+        });
+
+        it('initializes with a css color (HSV)', async () => {
+            const image = await Jimp.create(2, 2, 'hsv (0%, 0%, 100%)');
+            image.getPixelColor(1, 1).should.be.equal(0xffffffff);
+        });
+
+        it('initializes with a css color (HSVA)', async () => {
+            const image = await Jimp.create(2, 2, 'hsva (0%, 0%, 100%, 1)');
+            image.getPixelColor(1, 1).should.be.equal(0xffffffff);
+        });
+
+        it('initializes with a css color (Named)', async () => {
+            const image = await Jimp.create(2, 2, 'WHITE');
+            image.getPixelColor(1, 1).should.be.equal(0xffffffff);
         });
     });
 

--- a/test/events.test.js
+++ b/test/events.test.js
@@ -21,16 +21,12 @@ describe('Events', () => {
                 .on('error', done);
         });
 
-        it('initializes with a color', done => {
-            new Jimp(2, 2, 0xffffffff)
-                .on('initialized', function() {
-                    this.getPixelColor(1, 1).should.be.equal(0xffffffff);
-                    done();
-                })
-                .on('error', done);
+        // (8bit Hex, Hex, RGB, RGBA, HSL, HSLA, HSV, HSVA, Named)
+        it('initializes with a 8bit hex color', async () => {
+            const image = await Jimp.create(2, 2, 0xffffffff);
+            image.getPixelColor(1, 1).should.be.equal(0xffffffff);
         });
 
-        // (Hex, RGB, RGBA, HSL, HSLA, HSV, HSVA, Named)
         it('initializes with a css color (Hex)', async () => {
             const image = await Jimp.create(2, 2, '#FFFFFF');
             image.getPixelColor(1, 1).should.be.equal(0xffffffff);

--- a/test/events.test.js
+++ b/test/events.test.js
@@ -20,6 +20,24 @@ describe('Events', () => {
                 })
                 .on('error', done);
         });
+
+        it('initializes with a color', done => {
+            new Jimp(2, 2, 0xffffffff)
+                .on('initialized', function() {
+                    this.getPixelColor(1, 1).should.be.equal(0xffffffff);
+                    done();
+                })
+                .on('error', done);
+        });
+
+        it('initializes with a css color', done => {
+            new Jimp(2, 2, '#FFFFFF')
+                .on('initialized', function() {
+                    this.getPixelColor(1, 1).should.be.equal(0xffffffff);
+                    done();
+                })
+                .on('error', done);
+        });
     });
 
     describe('on change', () => {


### PR DESCRIPTION
# What's Changing and Why

Adds the popular css hex color format for creating a new jimp. 

`new Jimp(512, 512, '#D95353', (image) => {});`

## What else might be affected
Added a conversion function from css hex color to hex

Also added tests for creating image with hex color and css color.

