### PR TITLE
Disable process.on on browser

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -40,7 +40,9 @@ for (let i = 2; i < 65; i++) {
     maxHashLength.push(maxHash.length);
 }
 
-process.on('exit', clear);
+if (!process.browser) {
+    process.on('exit', clear);
+}
 
 // no operation
 function noop() {}


### PR DESCRIPTION
# What's Changing and Why

Disable `process.on` because it doesn't work on browser. browser have no 'process'

## What else might be affected

nothing

## Tasks

-   [ ] Add tests
-   [ ] Update Documentation
-   [ ] Update `jimp.d.ts`
-   [ ] Add [SemVer](https://semver.org/) Label
