### PR TITLE
Fix rest parameters to be array types

### DIFF
--- a/jimp.d.ts
+++ b/jimp.d.ts
@@ -494,12 +494,12 @@ declare namespace Jimp {
         // Functions
         static appendConstructorOption<T extends any[]>(
             name: string,
-            test: (...args: T) => boolean,
+            test: (...args: T[]) => boolean,
             run: (
                 this: Jimp,
                 resolve: (jimp: Jimp) => any,
                 reject: (reason: Error) => any,
-                ...args: T
+                ...args: T[]
             ) => any
         );
         static read(path: string): Promise<Jimp>;


### PR DESCRIPTION
# What's Changing and Why

Fix rest parameters to be array types.
Typescript version is 2.9.2

## What else might be affected

I guess nothing.

## Tasks

-   [ ] Add tests
-   [ ] Update Documentation
-   [ ] Update `jimp.d.ts`
-   [ ] Add [SemVer](https://semver.org/) Label
