### PR TITLE
get first letter rather than '0'. cause '0' might no be present

### DIFF
--- a/src/image-manipulation/text.js
+++ b/src/image-manipulation/text.js
@@ -155,7 +155,7 @@ export function print(font, x, y, text, maxWidth, maxHeight, cb) {
         y = maxHeight / 2 - measureTextHeight(font, text, maxWidth) / 2;
     }
 
-    const defaultCharWidth = font.chars[0].xadvance;
+    const defaultCharWidth = Object.entries(font.chars)[0][1].xadvance;
     const lines = splitLines(font, text, maxWidth);
 
     lines.forEach(line => {

--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,6 @@ import request from './request';
 
 import * as measureText from './utils/measure-text';
 import * as text from './image-manipulation/text';
-import * as text from './image-manipulation/text';
 import * as shape from './image-manipulation/shape';
 import * as color from './image-manipulation/color';
 import * as effects from './image-manipulation/effects';


### PR DESCRIPTION
# What's Changing and Why

some fonts might not have the '0' character so just get first char instead for default width

closes #562 

## What else might be affected

nothing

## Tasks

-   [ ] Add tests
-   [x] Update Documentation
-   [x] Update `jimp.d.ts`
-   [x] Add [SemVer](https://semver.org/) Label
