### PR TITLE
Fix raw buffer constructor example

### DIFF
--- a/README.md
+++ b/README.md
@@ -548,7 +548,7 @@ new Jimp(256, 256, '#FF00FF', function(err, image) {
 You can also initialize a new Jimp image with a raw image buffer:
 
 ```js
-new Jimp({ buffer: buffer, width: 1280, height: 768 }, (err, image) => {
+new Jimp({ data: buffer, width: 1280, height: 768 }, (err, image) => {
     // this image is 1280 x 768, pixels are loaded from the given buffer.
 });
 ```


### PR DESCRIPTION
# What's Changing and Why
Constructor expects `data`, not `buffer` field. The example provided fails with

    No matching constructor overloading was found.
    Please see the docs for how to call the Jimp constructor.

## What else might be affected

## Tasks

-   [ ] Add tests
-   [ ] Update Documentation
-   [ ] Update `jimp.d.ts`
-   [ ] Add [SemVer](https://semver.org/) Label

closes #565