### PR TITLE
Core-js conflict

### DIFF
--- a/packages/jimp/package.json
+++ b/packages/jimp/package.json
@@ -57,7 +57,8 @@
     "@babel/polyfill": "^7.0.0-rc.1",
     "@jimp/custom": "^0.3.7",
     "@jimp/plugins": "^0.3.7",
-    "@jimp/types": "^0.3.7"
+    "@jimp/types": "^0.3.7",
+    "core-js": "^2.5.7"
   },
   "devDependencies": {
     "babelify": "^9.0.0",


### PR DESCRIPTION
# What's Changing and Why

add explicit dependency for core-js. fixes the case where project depends on conflicting core-js version

closes #574 

## What else might be affected

nothing

## Tasks

- [x] Add tests
- [x] Update Documentation
- [x] Update `jimp.d.ts`
- [x] Add [SemVer](https://semver.org/) Label
