### PR TITLE
correct getBase64Async type def

### DIFF
--- a/packages/jimp/jimp.d.ts
+++ b/packages/jimp/jimp.d.ts
@@ -253,7 +253,7 @@ declare namespace Jimp {
     rgba(bool: boolean, cb?: Jimp.ImageCallback): this;
     quality(n: number, cb?: Jimp.ImageCallback): this;
     getBase64(mime: string, cb: GenericCallback<string, any, this>): this;
-    getBase64Async(mime: string): Promise<Jimp>;
+    getBase64Async(mime: string): Promise<string>;
     hash(cb?: GenericCallback<string, any, this>): this;
     hash(
       base: number | null | undefined,


### PR DESCRIPTION
# What's Changing and Why

fixes #623

## What else might be affected

## Tasks

- [ ] Add tests
- [ ] Update Documentation
- [x] Update `jimp.d.ts`
- [x] Add [SemVer](https://semver.org/) Label
