### PR TITLE
Fix: Blend mode needs to be specified within argument 4, which is an …

### DIFF
--- a/packages/jimp/README.md
+++ b/packages/jimp/README.md
@@ -132,7 +132,7 @@ image.crop( x, y, w, h );         // crop to the given region
 /* Composing */
 image.blit( src, x, y, [srcx, srcy, srcw, srch] );
                                   // blit the image with another Jimp image at x, y, optionally cropped.
-image.composite( src, x, y, [mode, opacitySource, opacityDest] );     // composites another Jimp image over this image at x, y
+image.composite( src, x, y, [{ mode, opacitySource, opacityDest }] );     // composites another Jimp image over this image at x, y
 image.mask( src, x, y );          // masks the image with another Jimp image at x, y using average pixel value
 image.convolute( kernel );        // applies a convolution kernel matrix to the image or a region
 
@@ -256,7 +256,7 @@ Jimp.BLEND_EXCLUSION;
 ```
 
 ```js
-image.composite(srcImage, 100, 0, Jimp.BLEND_MULTIPLY, 0.5, 0.9);
+image.composite(srcImage, 100, 0, { mode: Jimp.BLEND_MULTIPLY, opacitySource: 0.5, opacityDest: 0.9 });
 ```
 
 ### Writing text


### PR DESCRIPTION
…object called `option`.

Documentation incorrectly utilizes argument 5 and 6, which causes the library to then expect a function.

# What's Changing and Why
Documentation. It is incorrect.

## What else might be affected

## Tasks

- [ ] Add tests
- [ ] Update Documentation
- [ ] Update `jimp.d.ts`
- [ ] Add [SemVer](https://semver.org/) Label
