### PR TITLE
Expose ParseBitmap

### DIFF
--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -312,7 +312,7 @@ class Jimp extends EventEmitter {
           return throwError.call(this, err, finish);
         }
 
-        parseBitmap.call(this, data, path, finish);
+        this.parseBitmap(data, path, finish);
       });
     } else if (typeof args[0] === 'object' && Buffer.isBuffer(args[0])) {
       // read from a buffer
@@ -323,7 +323,7 @@ class Jimp extends EventEmitter {
         return throwError.call(this, 'cb must be a function', finish);
       }
 
-      parseBitmap.call(this, data, null, finish);
+      this.parseBitmap(data, null, finish);
     } else {
       // Allow client libs to add new ways to build a Jimp object.
       // Extra constructors must be added by `Jimp.appendConstructorOption()`
@@ -357,6 +357,18 @@ class Jimp extends EventEmitter {
         );
       }
     }
+  }
+
+  /**
+   * Parse a bitmap with the loaded image types.
+   *
+   * @param {Buffer} data raw image data
+   * @param {string} path optional path to file
+   * @param {function(Error, Jimp)} cb (optional) a callback for when complete
+   * @memberof Jimp
+   */
+  parseBitmap(data, path, finish) {
+    parseBitmap.call(this, data, null, finish);
   }
 
   /**

--- a/packages/jimp/README.md
+++ b/packages/jimp/README.md
@@ -110,6 +110,49 @@ Jimp.read('http://www.example.com/path/to/lenna.jpg')
 
 The conveniance method `Jimp.create` also exists. It is just a wrapper around `Jimp.read`.
 
+### Custom Constructor
+
+You might want to initialize jimp in so custom way. To do this Jimp exposes the static function `appendConstructorOption`. The appended constructor options run after all the defaults.
+
+To define a custom constructor provide a name for it, a function to call to determine if the arguments provided to jimp match your constructor, and a function called where you can construct the image however you want.
+
+```js
+Jimp.appendConstructorOption(
+  'Name of Option',
+  args => arg.hasSomeCustomThing,
+  function(resolve, reject, args) {
+    this.bitmap = customParser(args);
+    resolve();
+  }
+);
+```
+
+If you don't want to handle parsing the bitmap. For example if you want to do some sort of authentication for URL request. Jimp exposes `parseBitmap` so you can fall back to jimp to do the heavy lifting.
+
+Parse bitmap takes the raw image data in a Buffer, a path (optional), and a node style callback.
+
+```js
+Jimp.appendConstructorOption('Custom Url', options => options.url, function(
+  resolve,
+  reject,
+  options
+) {
+  phin(options, (err, res) => {
+    if (err) {
+      return reject(err);
+    }
+
+    this.parseBitmap(res.body, options.url, err => {
+      if (err) {
+        return reject(err);
+      }
+
+      resolve();
+    });
+  });
+});
+```
+
 ### Methods
 
 Once the promise is fulfilled, the following methods can be called on the image:

--- a/packages/jimp/jimp.d.ts
+++ b/packages/jimp/jimp.d.ts
@@ -236,6 +236,11 @@ declare namespace Jimp {
       event: T,
       cb: (data: ListenerData<T>) => any
     ): any;
+    parseBitmap(
+      data: Buffer,
+      path: string | null | undefined,
+      cb?: Jimp.ImageCallback
+    );
     hasAlpha(): boolean;
     getHeight(): number;
     getWidth(): number;

--- a/packages/plugin-color/src/index.js
+++ b/packages/plugin-color/src/index.js
@@ -1,5 +1,5 @@
 import tinyColor from 'tinycolor2';
-import { throwError, isNodePattern, limit255 } from '@jimp/utils';
+import { throwError, isNodePattern } from '@jimp/utils';
 
 function applyKernel(im, kernel, x, y) {
   const value = [0, 0, 0];

--- a/packages/plugin-print/test/print.test.js
+++ b/packages/plugin-print/test/print.test.js
@@ -1,6 +1,5 @@
 /* eslint key-spacing: ["error", { "align": "value" }] */
 
-import fs from 'fs';
 import { Jimp, getTestDir, hasOwnProp } from '@jimp/test-utils';
 import configure from '@jimp/custom';
 import blit from '@jimp/plugin-blit';

--- a/packages/type-png/test/png.test.js
+++ b/packages/type-png/test/png.test.js
@@ -1,6 +1,5 @@
 /* eslint-disable no-control-regex */
 
-import fs from 'fs';
 import { Jimp, getTestDir } from '@jimp/test-utils';
 import configure from '@jimp/custom';
 


### PR DESCRIPTION
# What's Changing and Why

Expose parse bitmap so appended constructors can fall back to normal image parsing. 

## What else might be affected

Nothing.

## Tasks

- [ ] Add tests
- [x] Update Documentation
- [x] Update `jimp.d.ts`
- [x] Add [SemVer](https://semver.org/) Label
