### PR TITLE
Correct mistype of variable name

### DIFF
--- a/packages/plugin-color/src/index.js
+++ b/packages/plugin-color/src/index.js
@@ -539,7 +539,7 @@ export default () => ({
 
     x = x || 0;
     y = y || 0;
-    w = isDef(w) ? x : this.bitmap.width - x;
+    w = isDef(w) ? w : this.bitmap.width - x;
     h = isDef(h) ? h : this.bitmap.height - y;
 
     const source = this.cloneQuiet();


### PR DESCRIPTION
Mistyped variable name 'x' for 'w' meant that pixelated areas were always exactly as wide as how far across the image they started. Ooops.

# What's Changing and Why

I've changed the variable name to what it should be. So it works.

## What else might be affected

Nothing.

## Tasks

- [ ] Add tests
- [ ] Update Documentation
- [ ] Update `jimp.d.ts`
- [ ] Add [SemVer](https://semver.org/) Label
