### PR TITLE
Make contrast behave more like CSS/Photoshop legacy constrast

### DIFF
--- a/packages/plugin-color/src/index.js
+++ b/packages/plugin-color/src/index.js
@@ -190,7 +190,7 @@ export default () => ({
       );
     }
 
-    const factor = (amount + 1) / (1 - amount);
+    const factor = (val + 1) / (1 - val);
 
     function adjust(value) {
       value = Math.floor(factor * (value - 127) + 127);

--- a/packages/plugin-color/src/index.js
+++ b/packages/plugin-color/src/index.js
@@ -190,30 +190,12 @@ export default () => ({
       );
     }
 
+    const factor = (amount + 1) / (1 - amount);
+
     function adjust(value) {
-      let x;
+      value = Math.floor(factor * (value - 127) + 127);
 
-      if (val < 0) {
-        x = value > 127 ? 1 - value / 255 : value / 255;
-
-        if (x < 0) {
-          x = 0;
-        }
-
-        x = 0.5 * Math.pow(x * 2, 1 + val);
-
-        return value > 127 ? (1.0 - x) * 255 : x * 255;
-      }
-
-      x = value > 127 ? 1 - value / 255 : value / 255;
-
-      if (x < 0) {
-        x = 0;
-      }
-
-      x = 0.5 * Math.pow(2 * x, val === 1 ? 127 : 1 / (1 - val));
-
-      return value > 127 ? (1 - x) * 255 : x * 255;
+      return value < 0 ? 0 : value > 255 ? 255 : value;
     }
 
     this.scanQuiet(0, 0, this.bitmap.width, this.bitmap.height, function(


### PR DESCRIPTION
# What's Changing and Why

The `contrast` function in the `color` package was modified to behave more like the CSS contrast filter or Photoshop's legacy contrast mode (eg negative values move towards mid gray, positive values push colors near mid to their dark/light extremes)

## What else might be affected

Nothing else in Jimp uses the `contrast` function, so *theoretically*, nothing.

## Tasks

- [ ] Add tests

It appears that there are not currently any tests for `contrast`.

Was going to add some, but could not get Jimp to clean/build/run tests etc on Windows after cloning and doing NPM install - someone may want to look into cross platform testing, whether all build/clean/test dependencies are correctly installed etc. - I did notice some *nix shell specific things like `rf` in there

However I have manually verified by eye that an image adjusted with this algorithm from -1 to 1 by increments of 0.1 looks correct compared to both Photoshop and CSS

Somebody on whose system Jimp **does** correctly build should do a sanity check before merging this branch though, just to be sure that I haven't broken anything, unlikely though it seems.

- [ ] Update Documentation

`contrast` does not change from the user's point of view, no changes to documentation needed

- [ ] Update `jimp.d.ts`

All changes are internal to the `contrast` function, not required

- [ ] Add [SemVer](https://semver.org/) Label