### PR TITLE
Add more details to the Align Modes in the doc

### DIFF
--- a/packages/jimp/README.md
+++ b/packages/jimp/README.md
@@ -316,6 +316,17 @@ Jimp.VERTICAL_ALIGN_MIDDLE;
 Jimp.VERTICAL_ALIGN_BOTTOM;
 ```
 
+Where the align mode changes the position of the associated axis as described in the table below.
+
+Align Mode | Axis Point
+--- | ---
+`Jimp.HORIZONTAL_ALIGN_LEFT` | Positions the x-axis at the left of the image
+`Jimp.HORIZONTAL_ALIGN_CENTER` | Positions the x-axis at the center of the image
+`Jimp.HORIZONTAL_ALIGN_RIGHT` | Positions the x-axis at the right of the image
+`Jimp.VERTICAL_ALIGN_TOP` | Positions the y-axis at the top of the image
+`Jimp.VERTICAL_ALIGN_MIDDLE` | Positions the y-axis at the center of the image
+`Jimp.VERTICAL_ALIGN_BOTTOM` | Positions the y-axis at the bottom of the image
+
 For example:
 
 ```js
@@ -389,7 +400,7 @@ Jimp.loadFont(pathOrURL).then(font => {
     },
     maxWidth,
     maxHeight
-  ); // prints 'Hello world!' on an image, middle and center-aligned
+  ); // prints 'Hello world!' on an image, middle and center-aligned, when x = 0 and y = 0
 });
 ```
 


### PR DESCRIPTION
# What's Changing and Why

I was having trouble recently figuring out how to center some text on an image and I kept thinking that the `Jimp.HORIZONTAL_ALIGN_CENTER` meant that the cursor position of the text object would be at its horizontal center, not that the position of the x-axis on the image to the center. After a bunch of trial and error, I finally realized that these align modes change the position of the axis that you're specifying.

I figured that adding this table and adjusting the example for `print` might help other users who may run into this issue.

## What else might be affected

Nothing, just docs :)

## Tasks

- [ ] Add tests
- [ ] Update Documentation
- [ ] Update `jimp.d.ts`
- [ ] Add [SemVer](https://semver.org/) Label
