### PR TITLE
Fix bug in autocrop with leaveBorder enabled

### DIFF
--- a/packages/plugin-crop/src/index.js
+++ b/packages/plugin-crop/src/index.js
@@ -140,7 +140,6 @@ export default function pluginCrop(event) {
 
             if (this.constructor.colorDiff(rgba1, rgba2) > tolerance) {
               // this pixel is too distant from the first one: abort this side scan
-              northPixelsToCrop -= leaveBorder;
               break north;
             }
           }
@@ -157,7 +156,6 @@ export default function pluginCrop(event) {
 
             if (this.constructor.colorDiff(rgba1, rgba2) > tolerance) {
               // this pixel is too distant from the first one: abort this side scan
-              eastPixelsToCrop -= leaveBorder;
               break east;
             }
           }
@@ -178,7 +176,6 @@ export default function pluginCrop(event) {
 
             if (this.constructor.colorDiff(rgba1, rgba2) > tolerance) {
               // this pixel is too distant from the first one: abort this side scan
-              southPixelsToCrop -= leaveBorder;
               break south;
             }
           }
@@ -199,7 +196,6 @@ export default function pluginCrop(event) {
 
             if (this.constructor.colorDiff(rgba1, rgba2) > tolerance) {
               // this pixel is too distant from the first one: abort this side scan
-              westPixelsToCrop -= leaveBorder;
               break west;
             }
           }
@@ -209,6 +205,12 @@ export default function pluginCrop(event) {
 
         // decide if a crop is needed
         let doCrop = false;
+
+        // apply leaveBorder
+        westPixelsToCrop = westPixelsToCrop - leaveBorder;
+        eastPixelsToCrop = eastPixelsToCrop - leaveBorder;
+        northPixelsToCrop = northPixelsToCrop - leaveBorder;
+        southPixelsToCrop = southPixelsToCrop - leaveBorder;
 
         if (cropSymmetric) {
           const horizontal = Math.min(eastPixelsToCrop, westPixelsToCrop);
@@ -224,6 +226,12 @@ export default function pluginCrop(event) {
           w - (westPixelsToCrop + eastPixelsToCrop);
         const heightOfRemainingPixels =
           h - (southPixelsToCrop + northPixelsToCrop);
+
+        // make sure that crops are > 0
+        westPixelsToCrop = westPixelsToCrop >= 0 ? westPixelsToCrop : 0;
+        eastPixelsToCrop = eastPixelsToCrop >= 0 ? eastPixelsToCrop : 0;
+        northPixelsToCrop = northPixelsToCrop >= 0 ? northPixelsToCrop : 0;
+        southPixelsToCrop = southPixelsToCrop >= 0 ? southPixelsToCrop : 0;
 
         if (cropOnlyFrames) {
           // crop image if all sides should be cropped

--- a/packages/plugin-crop/test/autocrop.test.js
+++ b/packages/plugin-crop/test/autocrop.test.js
@@ -5,7 +5,7 @@ import crop from '../src';
 
 const jimp = configure({ plugins: [crop] }, Jimp);
 
-describe('Autocrop', () => {
+describe.only('Autocrop', () => {
   it('image with transparent surround color', async () => {
     const imgSrc = await jimp.read(
       mkJGD(
@@ -280,6 +280,40 @@ describe('Autocrop', () => {
           '3  ◆▦▦◆  2',
           '2   ◆◆   3',
           '3232323232'
+        )
+      );
+  });
+
+  it('image with top and bottom frame and leaveBorder', async () => {
+    const imgSrc = await Jimp.read(
+      mkJGD(
+        '▥▥▥▥▥▥▥▥',
+        '▥▥▥▥▥▥▥▥',
+        '▥▥▥▥▥▥▥▥',
+        '   ◆◆   ',
+        '  ◆▦▦◆  ',
+        ' ◆▦▦▦▦◆ ',
+        '  ◆▦▦◆  ',
+        '   ◆◆   ',
+        '▥▥▥▥▥▥▥▥',
+        '▥▥▥▥▥▥▥▥',
+        '▥▥▥▥▥▥▥▥'
+      )
+    );
+    imgSrc
+      .autocrop({ cropSymmetric: true, cropOnlyFrames: false, leaveBorder: 2 })
+      .getJGDSync()
+      .should.be.sameJGD(
+        mkJGD(
+          '▥▥▥▥▥▥▥▥',
+          '▥▥▥▥▥▥▥▥',
+          '   ◆◆   ',
+          '  ◆▦▦◆  ',
+          ' ◆▦▦▦▦◆ ',
+          '  ◆▦▦◆  ',
+          '   ◆◆   ',
+          '▥▥▥▥▥▥▥▥',
+          '▥▥▥▥▥▥▥▥'
         )
       );
   });

--- a/packages/plugin-crop/test/autocrop.test.js
+++ b/packages/plugin-crop/test/autocrop.test.js
@@ -5,7 +5,7 @@ import crop from '../src';
 
 const jimp = configure({ plugins: [crop] }, Jimp);
 
-describe.only('Autocrop', () => {
+describe('Autocrop', () => {
   it('image with transparent surround color', async () => {
     const imgSrc = await jimp.read(
       mkJGD(


### PR DESCRIPTION
# What's Changing and Why
* Centralise application of border for a better overview 
* Add safety check for crops to be greater than or equal to 0
* Currently the crop size is always reduced by `leaveBorder` value, which can lead to negative values if the crop size is smaller than the border.

## What else might be affected
nothing

## Tasks

- [x] Add tests
- [x] Update Documentation => not needed
- [x] Update `jimp.d.ts` => not needed
- [x] Add [SemVer](https://semver.org/) Label
