### PR TITLE
dither is not a function

### DIFF
--- a/packages/plugin-dither/README.md
+++ b/packages/plugin-dither/README.md
@@ -19,7 +19,7 @@ import jimp from 'jimp';
 async function main() {
   const image = await jimp.read('test/image.png');
 
-  image.dither(150, jimp.AUTO);
+  image.dither565();
 }
 
 main();


### PR DESCRIPTION
# What's Changing and Why
this is a documentation change to reflect the correct exported methods.  I think the module exports `dither565` and `dither16` but not just `dither` like in the example.

## What else might be affected
nothing that i can see

## Tasks

- [ ] Add tests
- [x ] Update Documentation
- [ ] Update `jimp.d.ts`
- [ ] Add [SemVer](https://semver.org/) Label
