### PR TITLE
Fix cropping full width slices

### DIFF
--- a/packages/plugin-crop/src/index.js
+++ b/packages/plugin-crop/src/index.js
@@ -27,7 +27,7 @@ export default function pluginCrop(event) {
     if (x === 0 && w === this.bitmap.width) {
       // shortcut
       const start = (w * y + x) << 2;
-      const end = (start + h * w) << (2 + 1);
+      const end = (start + h * w) << 2;
 
       this.bitmap.data = this.bitmap.data.slice(start, end);
     } else {

--- a/packages/plugin-crop/test/crop.test.js
+++ b/packages/plugin-crop/test/crop.test.js
@@ -1,0 +1,110 @@
+import { Jimp, mkJGD } from '@jimp/test-utils';
+import configure from '@jimp/custom';
+
+import crop from '../src';
+
+const jimp = configure({ plugins: [crop] }, Jimp);
+
+describe('crop', () => {
+  // 6x5 size
+  const testImage = mkJGD(
+    '  ◆◆  ',
+    ' ◆▦▦◆ ',
+    '◆▦▦▦▦◆',
+    ' ◆▦▦◆ ',
+    '  ◆◆  '
+  );
+
+  it('full width from top', async () => {
+    const imgSrc = await jimp.read(testImage);
+
+    imgSrc
+      .crop(0, 0, 6, 2)
+      .getJGDSync()
+      .should.be.sameJGD(
+        mkJGD(
+          '  ◆◆  ',
+          ' ◆▦▦◆ ',
+        )
+      );
+  });
+
+  it('full width from bottom', async () => {
+    const imgSrc = await jimp.read(testImage);
+
+    imgSrc
+      .crop(0, 3, 6, 2)
+      .getJGDSync()
+      .should.be.sameJGD(
+        mkJGD(
+          ' ◆▦▦◆ ',
+          '  ◆◆  '
+        )
+      );
+  });
+  
+  it('full width from middle', async () => {
+    const imgSrc = await jimp.read(testImage);
+
+    imgSrc
+      .crop(0, 2, 6, 2)
+      .getJGDSync()
+      .should.be.sameJGD(
+        mkJGD(
+          '◆▦▦▦▦◆',
+          ' ◆▦▦◆ '
+        )
+      );
+  });
+  
+  it('full height from left', async () => {
+    const imgSrc = await jimp.read(testImage);
+
+    imgSrc
+      .crop(0, 0, 2, 5)
+      .getJGDSync()
+      .should.be.sameJGD(
+        mkJGD(
+          '  ',
+          ' ◆',
+          '◆▦',
+          ' ◆',
+          '  '
+        )
+      );
+  });
+
+  it('full height from right', async () => {
+    const imgSrc = await jimp.read(testImage);
+
+    imgSrc
+      .crop(4, 0, 2, 5)
+      .getJGDSync()
+      .should.be.sameJGD(
+        mkJGD(
+          '  ',
+          '◆ ',
+          '▦◆',
+          '◆ ',
+          '  '
+        )
+      );
+  });
+
+  it('full height from middle', async () => {
+    const imgSrc = await jimp.read(testImage);
+
+    imgSrc
+      .crop(2, 0, 2, 5)
+      .getJGDSync()
+      .should.be.sameJGD(
+        mkJGD(
+          '◆◆',
+          '▦▦',
+          '▦▦',
+          '▦▦',
+          '◆◆'
+        )
+      );
+  });
+});


### PR DESCRIPTION
# What's Changing and Why

Fixes #675.

## What else might be affected

Changes are limited to the crop plugin.

## Tasks

- [x] Add tests: I've added a few tests that check cropping full width/height slices from various starting positions. It doesn't cover the entire crop plugin but I think it's a good start.
- [ ] Update Documentation
- [ ] Update `jimp.d.ts`
- [ ] Add [SemVer](https://semver.org/) Label - should I bump the patch version?
