### PR TITLE
Fix: #745 Tyepscript definition wrong return type on hash()

### DIFF
--- a/packages/jimp/jimp.d.ts
+++ b/packages/jimp/jimp.d.ts
@@ -126,11 +126,11 @@ interface Jimp {
   quality(n: number, cb?: ImageCallback): this;
   getBase64(mime: string, cb: GenericCallback<string, any, this>): this;
   getBase64Async(mime: string): Promise<string>;
-  hash(cb?: GenericCallback<string, any, this>): this;
+  hash(cb?: GenericCallback<string, any, this>): string | Error;
   hash(
     base: number | null | undefined,
     cb?: GenericCallback<string, any, this>
-  ): this;
+  ): string | Error;
   getBuffer(mime: string, cb: GenericCallback<Buffer>): this;
   getBufferAsync(mime: string): Promise<Buffer>;
   getPixelIndex(

--- a/packages/jimp/jimp.d.ts
+++ b/packages/jimp/jimp.d.ts
@@ -126,11 +126,11 @@ interface Jimp {
   quality(n: number, cb?: ImageCallback): this;
   getBase64(mime: string, cb: GenericCallback<string, any, this>): this;
   getBase64Async(mime: string): Promise<string>;
-  hash(cb?: GenericCallback<string, any, this>): string | Error;
+  hash(cb?: GenericCallback<string, any, this>): string;
   hash(
     base: number | null | undefined,
     cb?: GenericCallback<string, any, this>
-  ): string | Error;
+  ): string;
   getBuffer(mime: string, cb: GenericCallback<Buffer>): this;
   getBufferAsync(mime: string): Promise<Buffer>;
   getPixelIndex(


### PR DESCRIPTION
# What's Changing and Why
According to #745, `jimp.d.ts` is having wrong return type `this` on `hash()`, which should be `string`
This PR fixed this.

## What else might be affected
Nothing

## Tasks

- [ ] Add tests
- [ ] Update Documentation
- [x] Update `jimp.d.ts`
- [ ] Add [SemVer](https://semver.org/) Label

closes #745