### PR TITLE
Replace `npm` usage with `yarn`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ If you know how to code, we welcome you to send fixes and new features, but in o
 - Code your changes (if you want to implement many features do each one in a separated branch);
 - Write tests to ensure your feature works as expected and protect its behavior on future changes;
 - Test it! Ensure you don't crash Jimp in Node.js or Browser environments;
-  - Full test with `npm test` will also produce a coverage report.
+  - Full test with `yarn test` will also produce a coverage report.
   - For more option, see the "[Testing](#testing)" topic bellow.
 - Push to your forked repo;
 - Make your pull request.
@@ -38,7 +38,7 @@ yarn build:watch # build ES5 version in watch mode. Good to run while testing or
 
 ### Testing
 
-The test framework runs at Node.js and browsers environments. Just run `npm test` to test in node and browser environments.
+The test framework runs at Node.js and browsers environments. Just run `yarn test` to test in node and browser environments.
 You can use the coverage report to help with missed tests, but you must be aware: it only shows if a line of code was evaluated while testing, not if all relevant test cases was done to protect the feature behavior.
 
 While developing you may want to test only on node.js:
@@ -65,7 +65,7 @@ yarn test:watch
 yarn run test:browser -- --browsers Firefox
 ```
 
-For more options and project management tools see: `npm run`
+For more options and project management tools see: `yarn run`
 
 ## Collaborators are Welcome
 


### PR DESCRIPTION
# What's Changing and Why
Seems this project uses `yarn` for package management

So I replaced some `npm` usages with `yarn` in documentation to avoid 'side effects', because other parts of the file already calls `yarn` and not `npm`

## What else might be affected
Nothing

## Tasks

- [ ] Add tests
- [X] Update Documentation
- [ ] Update `jimp.d.ts`
- [ ] Add [SemVer](https://semver.org/) Label
