### PR TITLE
Og convolute divisor

### DIFF
--- a/packages/plugin-color/README.md
+++ b/packages/plugin-color/README.md
@@ -240,6 +240,7 @@ Applies a convolution kernel to the image or a region
 - @param {number} y (optional) the y position of the region to apply convolution to
 - @param {number} w (optional) the width of the region to apply convolution to
 - @param {number} h (optional) the height of the region to apply convolution to
+- @param {number} divisor (optional) the final divisor to be applied to each value
 - @param {function(Error, Jimp)} cb (optional) a callback for when complete
 
 ```js

--- a/packages/plugin-color/README.md
+++ b/packages/plugin-color/README.md
@@ -236,11 +236,11 @@ main();
 Applies a convolution kernel to the image or a region
 
 - @param {array} kernel the convolution kernel
+- @param {number} divisor (optional) the final divisor to be applied to each value
 - @param {number} x (optional) the x position of the region to apply convolution to
 - @param {number} y (optional) the y position of the region to apply convolution to
 - @param {number} w (optional) the width of the region to apply convolution to
 - @param {number} h (optional) the height of the region to apply convolution to
-- @param {number} divisor (optional) the final divisor to be applied to each value
 - @param {function(Error, Jimp)} cb (optional) a callback for when complete
 
 ```js

--- a/packages/plugin-color/src/index.js
+++ b/packages/plugin-color/src/index.js
@@ -546,48 +546,50 @@ export default () => ({
   /**
    * Applies a convolution kernel to the image or a region
    * @param {array} kernel the convolution kernel
+   * @param {number} divisor (optional) the final divisor to be applied to each value
    * @param {number} x (optional) the x position of the region to apply convolution to
    * @param {number} y (optional) the y position of the region to apply convolution to
    * @param {number} w (optional) the width of the region to apply convolution to
    * @param {number} h (optional) the height of the region to apply convolution to
-   * @param {number} divisor (optional) the final divisor to be applied to each value
    * @param {function(Error, Jimp)} cb (optional) a callback for when complete
    * @returns {Jimp }this for chaining of methods
    */
-  convolute(kernel, x, y, w, h, divisor, cb) {
-    if (!Array.isArray(kernel))
-      return throwError.call(this, 'the kernel must be an array', cb);
+  convolute: function convolute(kernel, divisor, x, y, w, h, cb) {
+    if (!Array.isArray(kernel)) return _utils.throwError.call(this, 'the kernel must be an array', cb);
 
-    if (typeof x === 'function') {
-      cb = x;
+    if (typeof divisor === 'function') {
+      cb = divisor;
       x = null;
       y = null;
       w = null;
       h = null;
       divisor = 1;
     } else {
-      if (isDef(x) && typeof x !== 'number') {
-        return throwError.call(this, 'x must be a number', cb);
+      if (isDef(divisor) && (typeof divisor !== 'number' || divisor <= 0)) {
+        return throwError.call(this, 'divisor must be a non-zero, positive number', cb);
       }
-
-      if (isDef(y) && typeof y !== 'number') {
-        return throwError.call(this, 'y must be a number', cb);
-      }
-
-      if (isDef(w) && typeof w !== 'number') {
-        return throwError.call(this, 'w must be a number', cb);
-      }
-
-      if (isDef(h) && typeof h !== 'number') {
-        return throwError.call(this, 'h must be a number', cb);
-      }
-
-      if (isDef(cb)) {
-        if (isDef(divisor) && (typeof divisor !== 'number' || divisor <= 0)) {
-          return throwError.call(this, 'divisor must be a non-zero, positive number', cb);
-        }
+      if (isDef(divisor) && typeof divisor === 'number' && isDef(x) && typeof x === 'function') {
+        cb = x;
+        x = null;
+        y = null;
+        w = null;
+        h = null;
       } else {
-        divisor = 1;
+        if (isDef(x) && typeof x !== 'number') {
+          return _utils.throwError.call(this, 'x must be a number', cb);
+        }
+
+        if (isDef(y) && typeof y !== 'number') {
+          return _utils.throwError.call(this, 'y must be a number', cb);
+        }
+
+        if (isDef(w) && typeof w !== 'number') {
+          return _utils.throwError.call(this, 'w must be a number', cb);
+        }
+
+        if (isDef(h) && typeof h !== 'number') {
+          return _utils.throwError.call(this, 'h must be a number', cb);
+        }
       }
     }
 

--- a/packages/plugin-color/src/index.js
+++ b/packages/plugin-color/src/index.js
@@ -550,10 +550,11 @@ export default () => ({
    * @param {number} y (optional) the y position of the region to apply convolution to
    * @param {number} w (optional) the width of the region to apply convolution to
    * @param {number} h (optional) the height of the region to apply convolution to
+   * @param {number} divisor (optional) the final divisor to be applied to each value
    * @param {function(Error, Jimp)} cb (optional) a callback for when complete
    * @returns {Jimp }this for chaining of methods
    */
-  convolute(kernel, x, y, w, h, cb) {
+  convolute(kernel, x, y, w, h, divisor, cb) {
     if (!Array.isArray(kernel))
       return throwError.call(this, 'the kernel must be an array', cb);
 
@@ -563,6 +564,7 @@ export default () => ({
       y = null;
       w = null;
       h = null;
+      divisor = 1;
     } else {
       if (isDef(x) && typeof x !== 'number') {
         return throwError.call(this, 'x must be a number', cb);
@@ -579,6 +581,14 @@ export default () => ({
       if (isDef(h) && typeof h !== 'number') {
         return throwError.call(this, 'h must be a number', cb);
       }
+
+      if (isDef(cb)) {
+        if (isDef(divisor) && (typeof divisor !== 'number' || divisor <= 0)) {
+          return throwError.call(this, 'divisor must be a non-zero, positive number', cb);
+        }
+      } else {
+        divisor = 1;
+      }
     }
 
     const ksize = (kernel.length - 1) / 2;
@@ -592,7 +602,9 @@ export default () => ({
 
     this.scanQuiet(x, y, w, h, function(xx, yx, idx) {
       const value = applyKernel(source, kernel, xx, yx);
-
+      value[0] /= divisor;
+      value[1] /= divisor;
+      value[2] /= divisor;
       this.bitmap.data[idx] = this.constructor.limit255(value[0]);
       this.bitmap.data[idx + 1] = this.constructor.limit255(value[1]);
       this.bitmap.data[idx + 2] = this.constructor.limit255(value[2]);


### PR DESCRIPTION
# What's Changing and Why
This addresses FR #763 for convolution divisors. Apologies if it's not 100% how you'd have done it but I've tested two scenarios and it works as expected.

You could change the order of the arguments so that this is near the end. Honestly, I don't love these anonymous incoming variables which might be _this_ or _that_ depending upon the order. :P

## What else might be affected
Testing should be performed when the user includes the other optional arguments.

## Tasks

- [ ] Add tests (?)
- [x] Update Documentation
- [ ] Update `jimp.d.ts` (?)
- [ ] Add [SemVer](https://semver.org/) Label (?)

## Test code I used
```
# Within the context of a Node Express app's router in this case...
router.get('/', function(req, res, next) {
  var kernel =  [
                  [1,  4,  6,  4, 1],
                  [4, 16, 24, 16, 4],
                  [6, 24, 36, 24, 6],
                  [4, 16, 24, 16, 4],
                  [1,  4,  6,  4, 1]
                ];
  var divisor = 256;
  Jimp.read('test.png', function(errRead, fileIn) {
    if (errRead) throw errRead;

    // Also tested this by omitting the divisor argument below
    // which results in a very white output, as expected
    fileIn.convolute(kernel, divisor, function(errConvolute, fileAdjusted) {
      if (errConvolute) throw errConvolute;

      fileAdjusted.write('blurred.png', function(errWrite) {
        if (errWrite) throw errWrite;

        res.render('index', { title: 'Done' });
      });
    });
  });
});
```