### PR TITLE
must ship types

### DIFF
--- a/packages/jimp/package.json
+++ b/packages/jimp/package.json
@@ -19,7 +19,8 @@
     "dist",
     "es",
     "index.d.ts",
-    "fonts"
+    "fonts",
+    "types"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
# What's Changing and Why

Fixes #793 although this will not fix all the type problems


<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `0.8.2-canary.794.308.0`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
