### PR TITLE
TS 3.1 fixed

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -31,7 +31,7 @@
     "@types/mocha": "^5.2.5",
     "@types/yargs": "^11.1.1",
     "ts-node": "^7.0.1",
-    "typescript": "^3.0.3"
+    "typescript": "^3.1.3"
   },
   "nyc": {
     "extension": [

--- a/packages/core/types/etc.d.ts
+++ b/packages/core/types/etc.d.ts
@@ -27,7 +27,7 @@ export type ImageCallback<jimp = Jimp> = (
     x: number;
     y: number;
   }
-) => jimp;
+) => any;
 
 type BlendMode = {
   mode: string;

--- a/packages/core/types/etc.d.ts
+++ b/packages/core/types/etc.d.ts
@@ -15,15 +15,19 @@ export type GenericCallback<T, U = any, TThis = any> = (
   value: T
 ) => U;
 
-export type ImageCallback<U = any> = (
-  this: Jimp,
+/**
+ * `jimp` must be defined otherwise `this` will not apply properly
+ * for custom configurations where plugins and types are needed
+ */
+export type ImageCallback<jimp = Jimp> = (
+  this: jimp,
   err: Error | null,
-  value: Jimp,
+  value: jimp,
   coords: {
     x: number;
     y: number;
   }
-) => U;
+) => jimp;
 
 type BlendMode = {
   mode: string;

--- a/packages/core/types/jimp.d.ts
+++ b/packages/core/types/jimp.d.ts
@@ -10,18 +10,30 @@ import {
   RGB
 } from './etc';
 
+interface DiffReturn {
+  percent: number;
+  image: this;
+}
+
+interface ScanIteratorReturn {
+  x: number;
+  y: number;
+  idx: number;
+  image: this;
+}
+
 export interface JimpConstructors {
-  new(path: string, cb?: ImageCallback): this;
-  new(urlOptions: URLOptions, cb?: ImageCallback): this;
-  new(image: Jimp, cb?: ImageCallback): this;
-  new(data: Buffer, cb?: ImageCallback): this;
-  new(data: Bitmap, cb?: ImageCallback): this;
-  new(w: number, h: number, cb?: ImageCallback): this;
+  new(path: string, cb?: ImageCallback<this>): this;
+  new(urlOptions: URLOptions, cb?: ImageCallback<this>): this;
+  new(image: Jimp, cb?: ImageCallback<this>): this;
+  new(data: Buffer, cb?: ImageCallback<this>): this;
+  new(data: Bitmap, cb?: ImageCallback<this>): this;
+  new(w: number, h: number, cb?: ImageCallback<this>): this;
   new(
     w: number,
     h: number,
     background?: number | string,
-    cb?: ImageCallback
+    cb?: ImageCallback<this>
   ): this;
   // For custom constructors when using Jimp.appendConstructorOption
   new(...args: any[]): this;
@@ -66,7 +78,7 @@ export interface Jimp extends JimpConstructors {
   parseBitmap(
     data: Buffer,
     path: string | null | undefined,
-    cb?: ImageCallback
+    cb?: ImageCallback<this>
   ): void;
   hasAlpha(): boolean;
   getHeight(): number;
@@ -76,9 +88,9 @@ export interface Jimp extends JimpConstructors {
   getMIME(): string;
   getExtension(): string;
   distanceFromHash(hash: string): number;
-  write(path: string, cb?: ImageCallback): this;
+  write(path: string, cb?: ImageCallback<this>): this;
   writeAsync(path: string): Promise<this>;
-  rgba(bool: boolean, cb?: ImageCallback): this;
+  rgba(bool: boolean, cb?: ImageCallback<this>): this;
   getBase64(mime: string, cb: GenericCallback<string, any, this>): this;
   getBase64Async(mime: string): Promise<string>;
   hash(cb?: GenericCallback<string, any, this>): string;
@@ -109,19 +121,19 @@ export interface Jimp extends JimpConstructors {
     y: number,
     cb?: GenericCallback<number, any, this>
   ): number;
-  setPixelColor(hex: number, x: number, y: number, cb?: ImageCallback): this;
-  setPixelColour(hex: number, x: number, y: number, cb?: ImageCallback): this;
-  clone(cb?: ImageCallback): this;
-  cloneQuiet(cb?: ImageCallback): this;
-  background(hex: number, cb?: ImageCallback): this;
-  backgroundQuiet(hex: number, cb?: ImageCallback): this;
+  setPixelColor(hex: number, x: number, y: number, cb?: ImageCallback<this>): this;
+  setPixelColour(hex: number, x: number, y: number, cb?: ImageCallback<this>): this;
+  clone(cb?: ImageCallback<this>): this;
+  cloneQuiet(cb?: ImageCallback<this>): this;
+  background(hex: number, cb?: ImageCallback<this>): this;
+  backgroundQuiet(hex: number, cb?: ImageCallback<this>): this;
   scan(
     x: number,
     y: number,
     w: number,
     h: number,
     f: (this: this, x: number, y: number, idx: number) => any,
-    cb?: ImageCallback
+    cb?: ImageCallback<this>
   ): this;
   scanQuiet(
     x: number,
@@ -129,14 +141,14 @@ export interface Jimp extends JimpConstructors {
     w: number,
     h: number,
     f: (this: this, x: number, y: number, idx: number) => any,
-    cb?: ImageCallback
+    cb?: ImageCallback<this>
   ): this;
   scanIterator(
     x: number,
     y: number,
     w: number,
     h: number
-  ): IterableIterator<{ x: number; y: number; idx: number; image: Jimp }>;
+  ): IterableIterator<ScanIteratorReturn>;
 
   // Effect methods
   composite(
@@ -144,7 +156,7 @@ export interface Jimp extends JimpConstructors {
     x: number,
     y: number,
     options?: BlendMode,
-    cb?: ImageCallback
+    cb?: ImageCallback<this>
   ): this;
 
   // Functions
@@ -180,10 +192,7 @@ export interface Jimp extends JimpConstructors {
     img1: Jimp,
     img2: Jimp,
     threshold?: number
-  ): {
-    percent: number;
-    image: Jimp;
-  };
+  ): DiffReturn;
   distance(img1: Jimp, img2: Jimp): number;
   compareHashes(hash1: string, hash2: string): number;
   colorDiff(rgba1: RGB, rgba2: RGB): number;

--- a/packages/core/types/jimp.d.ts
+++ b/packages/core/types/jimp.d.ts
@@ -10,16 +10,16 @@ import {
   RGB
 } from './etc';
 
-interface DiffReturn {
+interface DiffReturn<This> {
   percent: number;
-  image: this;
+  image: This;
 }
 
-interface ScanIteratorReturn {
+interface ScanIteratorReturn<This> {
   x: number;
   y: number;
   idx: number;
-  image: this;
+  image: This;
 }
 
 export interface JimpConstructors {
@@ -148,7 +148,7 @@ export interface Jimp extends JimpConstructors {
     y: number,
     w: number,
     h: number
-  ): IterableIterator<ScanIteratorReturn>;
+  ): IterableIterator<ScanIteratorReturn<this>>;
 
   // Effect methods
   composite(
@@ -192,7 +192,7 @@ export interface Jimp extends JimpConstructors {
     img1: Jimp,
     img2: Jimp,
     threshold?: number
-  ): DiffReturn;
+  ): DiffReturn<this>;
   distance(img1: Jimp, img2: Jimp): number;
   compareHashes(hash1: string, hash2: string): number;
   colorDiff(rgba1: RGB, rgba2: RGB): number;

--- a/packages/core/types/utils.d.ts
+++ b/packages/core/types/utils.d.ts
@@ -1,5 +1,4 @@
 import {
-  WellFormedPlugin,
   JimpType,
   JimpPlugin,
 } from './plugins';

--- a/packages/custom/types/test.ts
+++ b/packages/custom/types/test.ts
@@ -54,6 +54,11 @@ test('should function the same as the `jimp` types', () => {
     // $ExpectType -1
     cloneBaseImage.PNG_FILTER_AUTO;
 
+    test('can handle `this` returns on the core type properly', () => {
+      // $ExpectType -1
+      cloneBaseImage.diff(jimpInst, jimpInst).image.PNG_FILTER_AUTO
+    });
+
     test('can handle `this` returns properly', () => {
       cloneBaseImage
         .resize(1, 1)

--- a/packages/custom/types/test.ts
+++ b/packages/custom/types/test.ts
@@ -13,6 +13,77 @@ const CustomJimp = configure({
   plugins: [displace, resize]
 });
 
+test('should function the same as the `jimp` types', () => {
+  const FullCustomJimp = configure({
+    types: [types],
+    plugins: [plugins]
+  });
+
+  const jimpInst = new FullCustomJimp('test');
+
+  // Main Jimp export should already have all of these already applied
+  jimpInst.read('Test');
+  jimpInst.displace(jimpInst, 2);
+  jimpInst.resize(40, 40);
+  // $ExpectType 0
+  jimpInst.PNG_FILTER_NONE;
+
+  // $ExpectError
+  jimpInst.test;
+
+  // $ExpectError
+  jimpInst.func();
+
+  // Main Jimp export should already have all of these already applied
+  FullCustomJimp.read('Test');
+  FullCustomJimp.displace(FullCustomJimp, 2);
+  FullCustomJimp.resize(40, 40);
+  // $ExpectType 0
+  FullCustomJimp.PNG_FILTER_NONE;
+
+  // $ExpectError
+  FullCustomJimp.test;
+
+  // $ExpectError
+  FullCustomJimp.func();
+
+  test('can clone properly', async () => {
+    const baseImage = await FullCustomJimp.read('filename');
+    const cloneBaseImage = baseImage.clone();
+
+    // $ExpectType -1
+    cloneBaseImage.PNG_FILTER_AUTO;
+
+    test('can handle `this` returns properly', () => {
+      cloneBaseImage
+        .resize(1, 1)
+        .crop(0, 0, 0, 0)
+        .mask(cloneBaseImage, 2, 2)
+        .print('a' as any, 2, 2, 'a' as any)
+        .resize(1, 1)
+        .quality(1)
+        .deflateLevel(2)
+        .PNG_FILTER_AUTO;
+    });
+
+    test('can handle imageCallbacks `this` properly', () => {
+      cloneBaseImage.rgba(false, (_, jimpCBIn) => {
+        jimpCBIn.read('Test');
+        jimpCBIn.displace(jimpInst, 2);
+        jimpCBIn.resize(40, 40);
+        // $ExpectType 0
+        jimpCBIn.PNG_FILTER_NONE;
+
+        // $ExpectError
+        jimpCBIn.test;
+
+        // $ExpectError
+        jimpCBIn.func();
+      })
+    })
+  });
+});
+
 test('can handle custom jimp', () => {
   // Methods from types should be applied
   CustomJimp.deflateLevel(4);

--- a/packages/jimp/package.json
+++ b/packages/jimp/package.json
@@ -6,6 +6,13 @@
   "module": "es/index.js",
   "browser": "browser/lib/jimp.js",
   "types": "types/index.d.ts",
+  "typesVersions": {
+    ">=3.1.0-0": {
+      "*": [
+        "types/ts3.1/index.d.ts"
+      ]
+    }
+  },
   "tonicExampleFilename": "example.js",
   "files": [
     "browser",

--- a/packages/jimp/types/index.d.ts
+++ b/packages/jimp/types/index.d.ts
@@ -1,29 +1,29 @@
 // TypeScript Version: 2.8
 
 
-declare const Jimp: Jimp;
+declare const DepreciatedJimp: DepreciatedJimp;
 
-export default Jimp;
+export default DepreciatedJimp;
 
 /**
  * @deprecated Jimp typings for TS <3.1 are being depreciated. Please upgrade your TypeScript version
  */
-interface Jimp {
+interface DepreciatedJimp {
   // Constructors
-  new(path: string, cb?: ImageCallback): Jimp;
-  new(urlOptions: URLOptions, cb?: ImageCallback): Jimp;
-  new(image: Jimp, cb?: ImageCallback): Jimp;
-  new(data: Buffer | Bitmap, cb?: ImageCallback): Jimp;
-  new(w: number, h: number, cb?: ImageCallback): Jimp;
+  new(path: string, cb?: ImageCallback): this;
+  new(urlOptions: URLOptions, cb?: ImageCallback): this;
+  new(image: DepreciatedJimp, cb?: ImageCallback): this;
+  new(data: Buffer | Bitmap, cb?: ImageCallback): this;
+  new(w: number, h: number, cb?: ImageCallback): this;
   new(
     w: number,
     h: number,
     background?: number | string,
     cb?: ImageCallback
-  ): Jimp;
+  ): this;
   // For custom constructors when using Jimp.appendConstructorOption
-  new(...args: any[]): Jimp;
-  prototype: Jimp;
+  new(...args: any[]): this;
+  prototype: this;
 
   // Constants
   AUTO: -1;
@@ -123,7 +123,7 @@ interface Jimp {
   getExtension(): string;
   distanceFromHash(hash: string): number;
   write(path: string, cb?: ImageCallback): this;
-  writeAsync(path: string): Promise<Jimp>;
+  writeAsync(path: string): Promise<this>;
   deflateLevel(l: number, cb?: ImageCallback): this;
   deflateStrategy(s: number, cb?: ImageCallback): this;
   colorType(s: number, cb?: ImageCallback): this;
@@ -187,7 +187,7 @@ interface Jimp {
     y: number,
     w: number,
     h: number
-  ): IterableIterator<{ x: number; y: number; idx: number; image: Jimp }>;
+  ): IterableIterator<{ x: number; y: number; idx: number; image: DepreciatedJimp }>;
   crop(x: number, y: number, w: number, h: number, cb?: ImageCallback): this;
   cropQuiet(
     x: number,
@@ -264,7 +264,7 @@ interface Jimp {
   scale(f: number, mode?: string, cb?: ImageCallback): this;
   scaleToFit(w: number, h: number, cb?: ImageCallback): this;
   scaleToFit(w: number, h: number, mode?: string, cb?: ImageCallback): this;
-  displace(map: Jimp, offset: number, cb?: ImageCallback): this;
+  displace(map: DepreciatedJimp, offset: number, cb?: ImageCallback): this;
   autocrop(tolerance?: number, cb?: ImageCallback): this;
   autocrop(cropOnlyFrames?: boolean, cb?: ImageCallback): this;
   autocrop(
@@ -321,15 +321,15 @@ interface Jimp {
   invert(cb?: ImageCallback): this;
   gaussian(r: number, cb?: ImageCallback): this;
   composite(
-    src: Jimp,
+    src: DepreciatedJimp,
     x: number,
     y: number,
     options?: BlendMode,
     cb?: ImageCallback
   ): this;
-  blit(src: Jimp, x: number, y: number, cb?: ImageCallback): this;
+  blit(src: DepreciatedJimp, x: number, y: number, cb?: ImageCallback): this;
   blit(
-    src: Jimp,
+    src: DepreciatedJimp,
     x: number,
     y: number,
     srcx: number,
@@ -338,46 +338,46 @@ interface Jimp {
     srch: number,
     cb?: ImageCallback
   ): this;
-  mask(src: Jimp, x: number, y: number, cb?: ImageCallback): this;
+  mask(src: this, x: number, y: number, cb?: ImageCallback): this;
 
   // Functions
   appendConstructorOption<T extends any[]>(
     name: string,
     test: (...args: T[]) => boolean,
     run: (
-      this: Jimp,
-      resolve: (jimp: Jimp) => any,
+      this: this,
+      resolve: (jimp: this) => any,
       reject: (reason: Error) => any,
       ...args: T[]
     ) => any
   ): void;
-  read(path: string): Promise<Jimp>;
-  read(image: Jimp): Promise<Jimp>;
-  read(data: Buffer): Promise<Jimp>;
-  read(w: number, h: number, background?: number | string): Promise<Jimp>;
-  create(path: string): Promise<Jimp>;
-  create(image: Jimp): Promise<Jimp>;
-  create(data: Buffer): Promise<Jimp>;
-  create(w: number, h: number, background?: number | string): Promise<Jimp>;
+  read(path: string): Promise<this>;
+  read(image: this): Promise<this>;
+  read(data: Buffer): Promise<this>;
+  read(w: number, h: number, background?: number | string): Promise<this>;
+  create(path: string): Promise<this>;
+  create(image: this): Promise<this>;
+  create(data: Buffer): Promise<this>;
+  create(w: number, h: number, background?: number | string): Promise<this>;
   rgbaToInt(
     r: number,
     g: number,
     b: number,
     a: number,
-    cb: GenericCallback<number, any, Jimp>
+    cb: GenericCallback<number, any, this>
   ): number;
   intToRGBA(i: number, cb?: GenericCallback<RGBA>): RGBA;
   cssColorToHex(cssColor: string): number;
   limit255(n: number): number;
   diff(
-    img1: Jimp,
-    img2: Jimp,
+    img1: this,
+    img2: this,
     threshold?: number
   ): {
     percent: number;
-    image: Jimp;
+    image: DepreciatedJimp;
   };
-  distance(img1: Jimp, img2: Jimp): number;
+  distance(img1: this, img2: this): number;
   compareHashes(hash1: string, hash2: string): number;
   colorDiff(rgba1: RGB, rgba2: RGB): number;
   colorDiff(rgba1: RGBA, rgba2: RGBA): number;
@@ -423,9 +423,9 @@ type GenericCallback<T, U = any, TThis = any> = (
 ) => U;
 
 type ImageCallback<U = any> = (
-  this: Jimp,
+  this: DepreciatedJimp,
   err: Error | null,
-  value: Jimp,
+  value: DepreciatedJimp,
   coords: {
     x: number;
     y: number;

--- a/packages/jimp/types/test.ts
+++ b/packages/jimp/types/test.ts
@@ -30,8 +30,36 @@ Jimp.func();
 
 test('can clone properly', async () => {
   const baseImage = await Jimp.read('filename');
-  const finalImage = baseImage.clone()
-    .resize(1, 1)
-    .setPixelColor(0x00000000, 0, 0)
-    .resize(2, 2);  
+  const cloneBaseImage = baseImage.clone();
+
+  // $ExpectType -1
+  cloneBaseImage.PNG_FILTER_AUTO;
+
+  test('can handle `this` returns properly', () => {
+    cloneBaseImage
+      .resize(1, 1)
+      .crop(0, 0, 0, 0)
+      .mask(cloneBaseImage, 2, 2)
+      .print('a' as any, 2, 2, 'a' as any)
+      .resize(1, 1)
+      .quality(1)
+      .deflateLevel(2)
+      .PNG_FILTER_AUTO;
+  });
+
+  test('can handle imageCallbacks `this` properly', () => {
+    cloneBaseImage.rgba(false, (_, jimpCBIn) => {
+      jimpCBIn.read('Test');
+      jimpCBIn.displace(jimpInst, 2);
+      jimpCBIn.resize(40, 40);
+      // $ExpectType 0
+      jimpCBIn.PNG_FILTER_NONE;
+
+      // $ExpectError
+      jimpCBIn.test;
+
+      // $ExpectError
+      jimpCBIn.func();
+    })
+  })
 });

--- a/packages/jimp/types/test.ts
+++ b/packages/jimp/types/test.ts
@@ -35,6 +35,11 @@ test('can clone properly', async () => {
   // $ExpectType -1
   cloneBaseImage.PNG_FILTER_AUTO;
 
+  test('can handle `this` returns on the core type properly', () => {
+    // $ExpectType -1
+    cloneBaseImage.diff(jimpInst, jimpInst).image.PNG_FILTER_AUTO
+  });
+
   test('can handle `this` returns properly', () => {
     cloneBaseImage
       .resize(1, 1)

--- a/packages/jimp/types/ts3.1/index.d.ts
+++ b/packages/jimp/types/ts3.1/index.d.ts
@@ -26,10 +26,10 @@ export { FontChar, FontInfo, FontCommon, Font } from '@jimp/plugin-print';
 
 type IntersectedPluginTypes = UnionToIntersection<
   GetPluginVal<Types> | GetPluginVal<Plugins>
-  >;
+>;
 
-type Jimp = InstanceType<JimpType & ThisType<JimpType & IntersectedPluginTypes>> & ThisType<JimpType & IntersectedPluginTypes> & IntersectedPluginTypes;
+type Jimp = InstanceType<JimpType> & IntersectedPluginTypes;
 
-declare const Jimp: JimpConstructors & ThisType<JimpType & IntersectedPluginTypes> & Jimp;
+declare const Jimp: JimpConstructors & Jimp;
 
 export default Jimp;

--- a/packages/jimp/types/ts3.1/test.ts
+++ b/packages/jimp/types/ts3.1/test.ts
@@ -28,23 +28,15 @@ Jimp.test;
 // $ExpectError
 Jimp.func();
 
-/**
- * FIXME: Enable the 3.1 typings again, this is the last part that needs
- *  fixing.
- *  
- *  3.1 typing can be fixed by adding the following to the package.json:
- "typesVersions": {
-    ">=3.1.0-0": {
-      "*": [
-        "types/ts3.1/index.d.ts"
-      ]
-    }
-  },
- */
 test('can clone properly', async () => {
   const baseImage = await Jimp.read('filename');
-  const finalImage = baseImage.clone()
+  const cloneBaseImage = baseImage.clone();
+
+  // $ExpectType -1
+  cloneBaseImage.PNG_FILTER_AUTO;
+
+  cloneBaseImage
     .resize(1, 1)
     .setPixelColor(0x00000000, 0, 0)
-    .resize(2, 2);
+    .resize(1, 1);
 });

--- a/packages/jimp/types/ts3.1/test.ts
+++ b/packages/jimp/types/ts3.1/test.ts
@@ -35,8 +35,31 @@ test('can clone properly', async () => {
   // $ExpectType -1
   cloneBaseImage.PNG_FILTER_AUTO;
 
-  cloneBaseImage
-    .resize(1, 1)
-    .setPixelColor(0x00000000, 0, 0)
-    .resize(1, 1);
+  test('can handle `this` returns properly', () => {
+    cloneBaseImage
+      .resize(1, 1)
+      .crop(0, 0, 0, 0)
+      .mask(cloneBaseImage, 2, 2)
+      .print('a' as any, 2, 2, 'a' as any)
+      .resize(1, 1)
+      .quality(1)
+      .deflateLevel(2)
+      .PNG_FILTER_AUTO;
+  });
+  
+  test('can handle imageCallbacks `this` properly', () => {
+    cloneBaseImage.rgba(false, (_, jimpCBIn) => {
+      jimpCBIn.read('Test');
+      jimpCBIn.displace(jimpInst, 2);
+      jimpCBIn.resize(40, 40);
+      // $ExpectType 0
+      jimpCBIn.PNG_FILTER_NONE;
+
+      // $ExpectError
+      jimpCBIn.test;
+
+      // $ExpectError
+      jimpCBIn.func();
+    })
+  })
 });

--- a/packages/jimp/types/ts3.1/test.ts
+++ b/packages/jimp/types/ts3.1/test.ts
@@ -35,6 +35,11 @@ test('can clone properly', async () => {
   // $ExpectType -1
   cloneBaseImage.PNG_FILTER_AUTO;
 
+  test('can handle `this` returns on the core type properly', () => {
+    // $ExpectType -1
+    cloneBaseImage.diff(jimpInst, jimpInst).image.PNG_FILTER_AUTO
+  });
+  
   test('can handle `this` returns properly', () => {
     cloneBaseImage
       .resize(1, 1)

--- a/packages/plugin-blit/index.d.ts
+++ b/packages/plugin-blit/index.d.ts
@@ -1,7 +1,7 @@
-import { Jimp, ImageCallback, IllformedPlugin } from '@jimp/core';
+import { Jimp, ImageCallback } from '@jimp/core';
 
 interface Blit {
-  blit(src: Jimp, x: number, y: number, cb?: ImageCallback): this;
+  blit(src: Jimp, x: number, y: number, cb?: ImageCallback<this>): this;
   blit(
     src: Jimp,
     x: number,
@@ -10,7 +10,7 @@ interface Blit {
     srcy: number,
     srcw: number,
     srch: number,
-    cb?: ImageCallback
+    cb?: ImageCallback<this>
   ): this;
 }
 

--- a/packages/plugin-blur/index.d.ts
+++ b/packages/plugin-blur/index.d.ts
@@ -1,7 +1,7 @@
 import { ImageCallback } from '@jimp/core';
 
 interface Blur {
-  blur(r: number, cb?: ImageCallback): this;
+  blur(r: number, cb?: ImageCallback<this>): this;
 }
 
 export default function(): Blur;

--- a/packages/plugin-circle/index.d.ts
+++ b/packages/plugin-circle/index.d.ts
@@ -5,8 +5,8 @@ interface Circle {
     radius: number,
     x: number,
     y: number
-  }, cb?: ImageCallback): this;
-  circle(cb?: ImageCallback): this;
+  }, cb?: ImageCallback<this>): this;
+  circle(cb?: ImageCallback<this>): this;
 }
 
 export default function(): Circle;

--- a/packages/plugin-color/index.d.ts
+++ b/packages/plugin-color/index.d.ts
@@ -16,41 +16,41 @@ type ColorAction = {
 };
 
 interface Color {
-  brightness(val: number, cb?: ImageCallback): this;
-  contrast(val: number, cb?: ImageCallback): this;
-  posterize(n: number, cb?: ImageCallback): this;
-  greyscale(cb?: ImageCallback): this;
-  grayscale(cb?: ImageCallback): this;
-  opacity(f: number, cb?: ImageCallback): this;
-  sepia(cb?: ImageCallback): this;
-  fade(f: number, cb?: ImageCallback): this;
-  convolution(kernel: number[][], cb?: ImageCallback): this;
+  brightness(val: number, cb?: ImageCallback<this>): this;
+  contrast(val: number, cb?: ImageCallback<this>): this;
+  posterize(n: number, cb?: ImageCallback<this>): this;
+  greyscale(cb?: ImageCallback<this>): this;
+  grayscale(cb?: ImageCallback<this>): this;
+  opacity(f: number, cb?: ImageCallback<this>): this;
+  sepia(cb?: ImageCallback<this>): this;
+  fade(f: number, cb?: ImageCallback<this>): this;
+  convolution(kernel: number[][], cb?: ImageCallback<this>): this;
   convolution<T>(
     kernel: number[][],
     edgeHandling: string,
-    cb?: ImageCallback
+    cb?: ImageCallback<this>
   ): this;
-  opaque(cb?: ImageCallback): this;
-  pixelate(size: number, cb?: ImageCallback): this;
+  opaque(cb?: ImageCallback<this>): this;
+  pixelate(size: number, cb?: ImageCallback<this>): this;
   pixelate(
     size: number,
     x: number,
     y: number,
     w: number,
     h: number,
-    cb?: ImageCallback
+    cb?: ImageCallback<this>
   ): this;
-  convolute(kernel: number[][], cb?: ImageCallback): this;
+  convolute(kernel: number[][], cb?: ImageCallback<this>): this;
   convolute(
     kernel: number[][],
     x: number,
     y: number,
     w: number,
     h: number,
-    cb?: ImageCallback
+    cb?: ImageCallback<this>
   ): this;
-  color(actions: ColorAction[], cb?: ImageCallback): this;
-  colour(actions: ColorAction[], cb?: ImageCallback): this;
+  color(actions: ColorAction[], cb?: ImageCallback<this>): this;
+  colour(actions: ColorAction[], cb?: ImageCallback<this>): this;
 }
 
 export default function(): Color;

--- a/packages/plugin-contain/index.d.ts
+++ b/packages/plugin-contain/index.d.ts
@@ -1,15 +1,15 @@
 import { ImageCallback } from '@jimp/core';
 
 interface Contain {
-  contain(w: number, h: number, cb?: ImageCallback): this;
-  contain(w: number, h: number, mode?: string, cb?: ImageCallback): this;
-  contain(w: number, h: number, alignBits?: number, cb?: ImageCallback): this;
+  contain(w: number, h: number, cb?: ImageCallback<this>): this;
+  contain(w: number, h: number, mode?: string, cb?: ImageCallback<this>): this;
+  contain(w: number, h: number, alignBits?: number, cb?: ImageCallback<this>): this;
   contain(
     w: number,
     h: number,
     alignBits?: number,
     mode?: string,
-    cb?: ImageCallback
+    cb?: ImageCallback<this>
   ): this;
 }
 

--- a/packages/plugin-cover/index.d.ts
+++ b/packages/plugin-cover/index.d.ts
@@ -1,14 +1,14 @@
 import { ImageCallback } from '@jimp/core';
 
 interface Cover {
-  cover(w: number, h: number, cb?: ImageCallback): this;
-  cover(w: number, h: number, alignBits?: number, cb?: ImageCallback): this;
+  cover(w: number, h: number, cb?: ImageCallback<this>): this;
+  cover(w: number, h: number, alignBits?: number, cb?: ImageCallback<this>): this;
   cover(
     w: number,
     h: number,
     alignBits?: number,
     mode?: string,
-    cb?: ImageCallback
+    cb?: ImageCallback<this>
   ): this;
 }
 

--- a/packages/plugin-crop/index.d.ts
+++ b/packages/plugin-crop/index.d.ts
@@ -1,20 +1,20 @@
 import { Jimp, ImageCallback } from '@jimp/core';
 
 interface CropClass {
-  crop(x: number, y: number, w: number, h: number, cb?: ImageCallback): this;
+  crop(x: number, y: number, w: number, h: number, cb?: ImageCallback<this>): this;
   cropQuiet(
     x: number,
     y: number,
     w: number,
     h: number,
-    cb?: ImageCallback
+    cb?: ImageCallback<this>
   ): this;
-  autocrop(tolerance?: number, cb?: ImageCallback): this;
-  autocrop(cropOnlyFrames?: boolean, cb?: ImageCallback): this;
+  autocrop(tolerance?: number, cb?: ImageCallback<this>): this;
+  autocrop(cropOnlyFrames?: boolean, cb?: ImageCallback<this>): this;
   autocrop(
     tolerance?: number,
     cropOnlyFrames?: boolean,
-    cb?: ImageCallback
+    cb?: ImageCallback<this>
   ): this;
   autocrop(
     options: {
@@ -23,7 +23,7 @@ interface CropClass {
       cropSymmetric?: boolean;
       leaveBorder?: number;
     },
-    cb?: ImageCallback
+    cb?: ImageCallback<this>
   ): this;
 }
 

--- a/packages/plugin-crop/index.d.ts
+++ b/packages/plugin-crop/index.d.ts
@@ -1,33 +1,34 @@
 import { Jimp, ImageCallback } from '@jimp/core';
 
-interface Crop<This = Jimp> {
-  class: {
-    crop(x: number, y: number, w: number, h: number, cb?: ImageCallback): This;
-    cropQuiet(
-      x: number,
-      y: number,
-      w: number,
-      h: number,
-      cb?: ImageCallback
-    ): This;
+interface CropClass {
+  crop(x: number, y: number, w: number, h: number, cb?: ImageCallback): this;
+  cropQuiet(
+    x: number,
+    y: number,
+    w: number,
+    h: number,
+    cb?: ImageCallback
+  ): this;
+  autocrop(tolerance?: number, cb?: ImageCallback): this;
+  autocrop(cropOnlyFrames?: boolean, cb?: ImageCallback): this;
+  autocrop(
+    tolerance?: number,
+    cropOnlyFrames?: boolean,
+    cb?: ImageCallback
+  ): this;
+  autocrop(
+    options: {
+      tolerance?: number;
+      cropOnlyFrames?: boolean;
+      cropSymmetric?: boolean;
+      leaveBorder?: number;
+    },
+    cb?: ImageCallback
+  ): this;
+}
 
-    autocrop(tolerance?: number, cb?: ImageCallback): This;
-    autocrop(cropOnlyFrames?: boolean, cb?: ImageCallback): This;
-    autocrop(
-      tolerance?: number,
-      cropOnlyFrames?: boolean,
-      cb?: ImageCallback
-    ): This;
-    autocrop(
-      options: {
-        tolerance?: number;
-        cropOnlyFrames?: boolean;
-        cropSymmetric?: boolean;
-        leaveBorder?: number;
-      },
-      cb?: ImageCallback
-    ): This;
-  }
+interface Crop {
+  class: CropClass
 }
 
 export default function(): Crop;

--- a/packages/plugin-displace/index.d.ts
+++ b/packages/plugin-displace/index.d.ts
@@ -1,7 +1,7 @@
-import { Jimp, ImageCallback, IllformedPlugin } from '@jimp/core';
+import { Jimp, ImageCallback } from '@jimp/core';
 
 interface Displace {
-  displace(map: Jimp, offset: number, cb?: ImageCallback): this;
+  displace(map: Jimp, offset: number, cb?: ImageCallback<this>): this;
 }
 
 export default function(): Displace;

--- a/packages/plugin-dither/index.d.ts
+++ b/packages/plugin-dither/index.d.ts
@@ -1,8 +1,8 @@
 import { ImageCallback } from '@jimp/core';
 
 interface Dither {
-  dither565(cb?: ImageCallback): this;
-  dither16(cb?: ImageCallback): this;
+  dither565(cb?: ImageCallback<this>): this;
+  dither16(cb?: ImageCallback<this>): this;
 }
 
 export default function(): Dither;

--- a/packages/plugin-fisheye/index.d.ts
+++ b/packages/plugin-fisheye/index.d.ts
@@ -1,8 +1,8 @@
 import { ImageCallback } from '@jimp/core';
 
 interface Fisheye {
-  fishEye(opts?: { r: number }, cb?: ImageCallback): this;
-  fishEye(cb?: ImageCallback): this;
+  fishEye(opts?: { r: number }, cb?: ImageCallback<this>): this;
+  fishEye(cb?: ImageCallback<this>): this;
 }
 
 export default function(): Fisheye;

--- a/packages/plugin-flip/index.d.ts
+++ b/packages/plugin-flip/index.d.ts
@@ -1,8 +1,8 @@
 import { ImageCallback } from '@jimp/core';
 
 interface Flip {
-  flip(horizontal: boolean, vertical: boolean, cb?: ImageCallback): this;
-  mirror(horizontal: boolean, vertical: boolean, cb?: ImageCallback): this;
+  flip(horizontal: boolean, vertical: boolean, cb?: ImageCallback<this>): this;
+  mirror(horizontal: boolean, vertical: boolean, cb?: ImageCallback<this>): this;
 }
 
 export default function(): Flip;

--- a/packages/plugin-gaussian/index.d.ts
+++ b/packages/plugin-gaussian/index.d.ts
@@ -1,7 +1,7 @@
 import { ImageCallback } from '@jimp/core';
 
 interface Gaussian {
-  gaussian(r: number, cb?: ImageCallback): this;
+  gaussian(r: number, cb?: ImageCallback<this>): this;
 }
 
 export default function(): Gaussian;

--- a/packages/plugin-invert/index.d.ts
+++ b/packages/plugin-invert/index.d.ts
@@ -1,7 +1,7 @@
 import { ImageCallback } from '@jimp/core';
 
 interface Invert {
-  invert(cb?: ImageCallback): this;
+  invert(cb?: ImageCallback<this>): this;
 }
 
 export default function(): Invert;

--- a/packages/plugin-mask/index.d.ts
+++ b/packages/plugin-mask/index.d.ts
@@ -1,7 +1,7 @@
 import { ImageCallback, Jimp } from '@jimp/core';
 
 interface Mask {
-  mask(src: Jimp, x: number, y: number, cb?: ImageCallback): this;
+  mask(src: Jimp, x: number, y: number, cb?: ImageCallback<this>): this;
 }
 
 export default function(): Mask;

--- a/packages/plugin-mask/index.d.ts
+++ b/packages/plugin-mask/index.d.ts
@@ -1,4 +1,4 @@
-import { IllformedPlugin, ImageCallback, Jimp } from '@jimp/core';
+import { ImageCallback, Jimp } from '@jimp/core';
 
 interface Mask {
   mask(src: Jimp, x: number, y: number, cb?: ImageCallback): this;

--- a/packages/plugin-normalize/index.d.ts
+++ b/packages/plugin-normalize/index.d.ts
@@ -1,7 +1,7 @@
 import { ImageCallback } from '@jimp/core';
 
 interface Normalize {
-  normalize(cb ?: ImageCallback): this;
+  normalize(cb ?: ImageCallback<this>): this;
 }
 
 export default function(): Normalize;

--- a/packages/plugin-print/index.d.ts
+++ b/packages/plugin-print/index.d.ts
@@ -62,7 +62,35 @@ type PrintableText =
   alignmentY: number;
 };
 
-interface Print<This = Jimp> {
+interface PrintClass {
+  // Text methods
+  print(
+    font: Font,
+    x: number,
+    y: number,
+    text: PrintableText,
+    cb?: ImageCallback
+  ): this;
+  print(
+    font: Font,
+    x: number,
+    y: number,
+    text: PrintableText,
+    maxWidth?: number,
+    cb?: ImageCallback
+  ): this;
+  print(
+    font: Font,
+    x: number,
+    y: number,
+    text: PrintableText,
+    maxWidth?: number,
+    maxHeight?: number,
+    cb?: ImageCallback
+  ): this;
+}
+
+interface Print {
   constants: {
     measureText(font: Font, text: PrintableText): number;
     measureTextHeight(font: Font, text: PrintableText, maxWidth: number): number;
@@ -87,33 +115,7 @@ interface Print<This = Jimp> {
     loadFont(file: string, cb: GenericCallback<Font, any, any>): Promise<never>;
   }
 
-  class: {
-    // Text methods
-    print(
-      font: Font,
-      x: number,
-      y: number,
-      text: PrintableText,
-      cb?: ImageCallback
-    ): This;
-    print(
-      font: Font,
-      x: number,
-      y: number,
-      text: PrintableText,
-      maxWidth?: number,
-      cb?: ImageCallback
-    ): This;
-    print(
-      font: Font,
-      x: number,
-      y: number,
-      text: PrintableText,
-      maxWidth?: number,
-      maxHeight?: number,
-      cb?: ImageCallback
-    ): This;
-  }
+  class: PrintClass
 }
 
 export default function(): Print;

--- a/packages/plugin-print/index.d.ts
+++ b/packages/plugin-print/index.d.ts
@@ -1,4 +1,4 @@
-import { Jimp, GenericCallback, ImageCallback } from '@jimp/core';
+import { GenericCallback, ImageCallback } from '@jimp/core';
 
 export interface FontChar {
   id: number;
@@ -69,7 +69,7 @@ interface PrintClass {
     x: number,
     y: number,
     text: PrintableText,
-    cb?: ImageCallback
+    cb?: ImageCallback<this>
   ): this;
   print(
     font: Font,
@@ -77,7 +77,7 @@ interface PrintClass {
     y: number,
     text: PrintableText,
     maxWidth?: number,
-    cb?: ImageCallback
+    cb?: ImageCallback<this>
   ): this;
   print(
     font: Font,
@@ -86,7 +86,7 @@ interface PrintClass {
     text: PrintableText,
     maxWidth?: number,
     maxHeight?: number,
-    cb?: ImageCallback
+    cb?: ImageCallback<this>
   ): this;
 }
 

--- a/packages/plugin-resize/index.d.ts
+++ b/packages/plugin-resize/index.d.ts
@@ -1,8 +1,8 @@
-import { Jimp, ImageCallback } from '@jimp/core';
+import { ImageCallback } from '@jimp/core';
 
 interface ResizeClass {
-  resize(w: number, h: number, cb?: ImageCallback): this;
-  resize(w: number, h: number, mode?: string, cb?: ImageCallback): this;
+  resize(w: number, h: number, cb?: ImageCallback<this>): this;
+  resize(w: number, h: number, mode?: string, cb?: ImageCallback<this>): this;
 }
 
 interface Resize {

--- a/packages/plugin-resize/index.d.ts
+++ b/packages/plugin-resize/index.d.ts
@@ -1,6 +1,11 @@
 import { Jimp, ImageCallback } from '@jimp/core';
 
-interface Resize<This = Jimp> {
+interface ResizeClass {
+  resize(w: number, h: number, cb?: ImageCallback): this;
+  resize(w: number, h: number, mode?: string, cb?: ImageCallback): this;
+}
+
+interface Resize {
   constants: {
     // resize methods
     RESIZE_NEAREST_NEIGHBOR: 'nearestNeighbor';
@@ -10,10 +15,7 @@ interface Resize<This = Jimp> {
     RESIZE_BEZIER: 'bezierInterpolation';
   }
 
-  class: {
-    resize(w: number, h: number, cb?: ImageCallback): This;
-    resize(w: number, h: number, mode?: string, cb?: ImageCallback): This;
-  }
+  class: ResizeClass
 }
 
 export default function(): Resize;

--- a/packages/plugin-rotate/index.d.ts
+++ b/packages/plugin-rotate/index.d.ts
@@ -1,8 +1,8 @@
 import { ImageCallback } from '@jimp/core';
 
 interface Rotate {
-  rotate(deg: number, cb?: ImageCallback): this;
-  rotate(deg: number, mode: string | boolean, cb?: ImageCallback): this;
+  rotate(deg: number, cb?: ImageCallback<this>): this;
+  rotate(deg: number, mode: string | boolean, cb?: ImageCallback<this>): this;
 }
 
 export default function(): Rotate;

--- a/packages/plugin-scale/index.d.ts
+++ b/packages/plugin-scale/index.d.ts
@@ -1,10 +1,10 @@
 import { ImageCallback } from '@jimp/core';
 
 interface Scale {
-  scale(f: number, cb?: ImageCallback): this;
-  scale(f: number, mode?: string, cb?: ImageCallback): this;
-  scaleToFit(w: number, h: number, cb?: ImageCallback): this;
-  scaleToFit(w: number, h: number, mode?: string, cb?: ImageCallback): this;
+  scale(f: number, cb?: ImageCallback<this>): this;
+  scale(f: number, mode?: string, cb?: ImageCallback<this>): this;
+  scaleToFit(w: number, h: number, cb?: ImageCallback<this>): this;
+  scaleToFit(w: number, h: number, mode?: string, cb?: ImageCallback<this>): this;
 }
 
 export default function(): Scale;

--- a/packages/plugin-shadow/index.d.ts
+++ b/packages/plugin-shadow/index.d.ts
@@ -7,8 +7,8 @@ interface Shadow {
            x?: number,
            y?: number
          },
-         cb?: ImageCallback): this;
-  shadow(cb?: ImageCallback): this;
+         cb?: ImageCallback<this>): this;
+  shadow(cb?: ImageCallback<this>): this;
 }
 
 export default function(): Shadow;

--- a/packages/plugin-threshold/index.d.ts
+++ b/packages/plugin-threshold/index.d.ts
@@ -5,7 +5,7 @@ interface Threshold {
     max: number,
     replace?: number,
     autoGreyscale?: boolean
-  }, cb?: ImageCallback): this;
+  }, cb?: ImageCallback<this>): this;
 }
 
 export default function(): Threshold;

--- a/packages/type-jpeg/index.d.ts
+++ b/packages/type-jpeg/index.d.ts
@@ -1,9 +1,9 @@
-import { Jimp, DecoderFn, EncoderFn, ImageCallback } from '@jimp/core';
+import { DecoderFn, EncoderFn, ImageCallback } from '@jimp/core';
 
 interface JpegClass {
   MIME_JPEG: 'image/jpeg';
   _quality: number;
-  quality: (n: number, cb?: ImageCallback) => this;
+  quality: (n: number, cb?: ImageCallback<this>) => this;
 }
 
 interface Jpeg {

--- a/packages/type-jpeg/index.d.ts
+++ b/packages/type-jpeg/index.d.ts
@@ -1,6 +1,12 @@
 import { Jimp, DecoderFn, EncoderFn, ImageCallback } from '@jimp/core';
 
-interface Jpeg<This = Jimp> {
+interface JpegClass {
+  MIME_JPEG: 'image/jpeg';
+  _quality: number;
+  quality: (n: number, cb?: ImageCallback) => this;
+}
+
+interface Jpeg {
   mime: { 'image/jpeg': string[] },
 
   constants: {
@@ -15,11 +21,7 @@ interface Jpeg<This = Jimp> {
     'image/jpeg': DecoderFn
   }
 
-  class: {
-    MIME_JPEG: 'image/jpeg';
-    _quality: number;
-    quality: (n: number, cb?: ImageCallback) => This;
-  }
+  class: JpegClass
 }
 
 export default function(): Jpeg;

--- a/packages/type-png/index.d.ts
+++ b/packages/type-png/index.d.ts
@@ -1,6 +1,17 @@
 import { Jimp, DecoderFn, EncoderFn, ImageCallback } from '@jimp/core';
 
-interface PNG<This = Jimp> {
+interface PNGClass {
+  _deflateLevel: number,
+  _deflateStrategy: number,
+  _filterType: number,
+  _colorType: number,
+  deflateLevel(l: number, cb?: ImageCallback): this;
+  deflateStrategy(s: number, cb?: ImageCallback): this;
+  filterType(f: number, cb?: ImageCallback): this;
+  colorType(s: number, cb?: ImageCallback): this;
+}
+
+interface PNG {
 
   mime: { 'image/png': string[] },
 
@@ -13,16 +24,8 @@ interface PNG<This = Jimp> {
     'image/png': EncoderFn
   }
 
-  class: {
-    _deflateLevel: number,
-    _deflateStrategy: number,
-    _filterType: number,
-    _colorType: number,
-    deflateLevel(l: number, cb?: ImageCallback): This;
-    deflateStrategy(s: number, cb?: ImageCallback): This;
-    filterType(f: number, cb?: ImageCallback): This;
-    colorType(s: number, cb?: ImageCallback): This;
-  }
+  class: PNGClass
+  
   constants: {
     MIME_PNG: 'image/png';
     // PNG filter types

--- a/packages/type-png/index.d.ts
+++ b/packages/type-png/index.d.ts
@@ -1,14 +1,14 @@
-import { Jimp, DecoderFn, EncoderFn, ImageCallback } from '@jimp/core';
+import { DecoderFn, EncoderFn, ImageCallback } from '@jimp/core';
 
 interface PNGClass {
   _deflateLevel: number,
   _deflateStrategy: number,
   _filterType: number,
   _colorType: number,
-  deflateLevel(l: number, cb?: ImageCallback): this;
-  deflateStrategy(s: number, cb?: ImageCallback): this;
-  filterType(f: number, cb?: ImageCallback): this;
-  colorType(s: number, cb?: ImageCallback): this;
+  deflateLevel(l: number, cb?: ImageCallback<this>): this;
+  deflateStrategy(s: number, cb?: ImageCallback<this>): this;
+  filterType(f: number, cb?: ImageCallback<this>): this;
+  colorType(s: number, cb?: ImageCallback<this>): this;
 }
 
 interface PNG {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9097,9 +9097,10 @@ typescript-memoize@^1.0.0-alpha.3:
   dependencies:
     core-js "2.4.1"
 
-typescript@^3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.0.3.tgz#4853b3e275ecdaa27f78fda46dc273a7eb7fc1c8"
+typescript@^3.1.3:
+  version "3.6.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.3.tgz#fea942fabb20f7e1ca7164ff626f1a9f3f70b4da"
+  integrity sha512-N7bceJL1CtRQ2RiG0AQME13ksR7DiuQh/QehubYcghzv20tnh+MQnQIuJddTmsbqYj+dztchykemz0zFzlvdQw==
 
 typescript@next:
   version "3.7.0-dev.20190907"


### PR DESCRIPTION
# What's Changing and Why

A MINOR semver change to 0.8.3 that fixes the final issues with the 3.1 typings mentioned in #785. The type tests are now EXTREMELY thorough and should have all of the major edgecases and "gotchas" covered

## Tasks

- [x] Add tests
- [ ] Update Documentation
- [x] Update `jimp.d.ts`
- [ ] Add [SemVer](https://semver.org/) Label

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `0.8.4-canary.798.377.0`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
