### PR TITLE
Added back mention of required tsconfig options

### DIFF
--- a/packages/jimp/README.md
+++ b/packages/jimp/README.md
@@ -63,7 +63,11 @@ If you're using this library with TypeScript the method of importing slightly di
 import Jimp from 'jimp';
 ```
 
-**Note**: This change in import does not change the runtime behavior of your code at all.
+This requires setting the `allowSyntheticDefaultImports` compiler option to `true` in your `tsconfig`
+
+**Note 1**: `esModuleInterop` implicitly sets `allowSyntheticDefaultImports` to `true`
+
+**Note 2**: `allowSyntheticDefaultImports` nor `esModuleInterop` change the runtime behavior of your code at all. They are just flags that tells TypeScript you need the compatibility they offer.
 
 ## Module Build
 


### PR DESCRIPTION
# What's Changing and Why

I've come to realize that your TS project will need one of these settings set to true. As such, I've added back a note in the README that was mistakenly removed in c59bd6a

## Tasks

- [ ] Add tests
- [x] Update Documentation
- [ ] Update `jimp.d.ts`
- [ ] Add [SemVer](https://semver.org/) Label

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `0.8.5-canary.800.426.0`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
