### PR TITLE
Added callback to jimp constructor typings

### DIFF
--- a/packages/core/types/jimp.d.ts
+++ b/packages/core/types/jimp.d.ts
@@ -121,8 +121,18 @@ export interface Jimp extends JimpConstructors {
     y: number,
     cb?: GenericCallback<number, any, this>
   ): number;
-  setPixelColor(hex: number, x: number, y: number, cb?: ImageCallback<this>): this;
-  setPixelColour(hex: number, x: number, y: number, cb?: ImageCallback<this>): this;
+  setPixelColor(
+    hex: number,
+    x: number,
+    y: number,
+    cb?: ImageCallback<this>
+  ): this;
+  setPixelColour(
+    hex: number,
+    x: number,
+    y: number,
+    cb?: ImageCallback<this>
+  ): this;
   clone(cb?: ImageCallback<this>): this;
   cloneQuiet(cb?: ImageCallback<this>): this;
   background(hex: number, cb?: ImageCallback<this>): this;
@@ -170,10 +180,15 @@ export interface Jimp extends JimpConstructors {
       ...args: T[]
     ) => any
   ): void;
-  read(path: string): Promise<this>;
-  read(image: Jimp): Promise<this>;
-  read(data: Buffer): Promise<this>;
-  read(w: number, h: number, background?: number | string): Promise<this>;
+  read(path: string, cb?: ImageCallback<this>): Promise<this>;
+  read(image: Jimp, cb?: ImageCallback<this>): Promise<this>;
+  read(data: Buffer, cb?: ImageCallback<this>): Promise<this>;
+  read(
+    w: number,
+    h: number,
+    background?: number | string,
+    cb?: ImageCallback<this>
+  ): Promise<this>;
   create(path: string): Promise<this>;
   create(image: Jimp): Promise<this>;
   create(data: Buffer): Promise<this>;
@@ -188,11 +203,7 @@ export interface Jimp extends JimpConstructors {
   intToRGBA(i: number, cb?: GenericCallback<RGBA>): RGBA;
   cssColorToHex(cssColor: string): number;
   limit255(n: number): number;
-  diff(
-    img1: Jimp,
-    img2: Jimp,
-    threshold?: number
-  ): DiffReturn<this>;
+  diff(img1: Jimp, img2: Jimp, threshold?: number): DiffReturn<this>;
   distance(img1: Jimp, img2: Jimp): number;
   compareHashes(hash1: string, hash2: string): number;
   colorDiff(rgba1: RGB, rgba2: RGB): number;

--- a/packages/jimp/types/index.d.ts
+++ b/packages/jimp/types/index.d.ts
@@ -351,11 +351,15 @@ interface DepreciatedJimp {
       ...args: T[]
     ) => any
   ): void;
-  read(path: string): Promise<this>;
-  read(image: this): Promise<this>;
-  read(data: Buffer): Promise<this>;
-  read(w: number, h: number, background?: number | string): Promise<this>;
-  create(path: string): Promise<this>;
+  read(path: string, cb?: ImageCallback): Promise<this>;
+  read(image: this, cb?: ImageCallback): Promise<this>;
+  read(data: Buffer, cb?: ImageCallback): Promise<this>;
+  read(
+    w: number,
+    h: number,
+    background?: number | string,
+    cb?: ImageCallback
+  ): Promise<this>;  create(path: string): Promise<this>;
   create(image: this): Promise<this>;
   create(data: Buffer): Promise<this>;
   create(w: number, h: number, background?: number | string): Promise<this>;

--- a/packages/jimp/types/test.ts
+++ b/packages/jimp/types/test.ts
@@ -68,3 +68,21 @@ test('can clone properly', async () => {
     })
   })
 });
+
+test('Can handle callback with constructor', () => {
+  const myBmpBuffer: Buffer = {} as any;
+
+  Jimp.read(myBmpBuffer, (err, cbJimpInst) => {
+    cbJimpInst.read('Test');
+    cbJimpInst.displace(jimpInst, 2);
+    cbJimpInst.resize(40, 40);
+    // $ExpectType 0
+    cbJimpInst.PNG_FILTER_NONE;
+
+    // $ExpectError
+    cbJimpInst.test;
+
+    // $ExpectError
+    cbJimpInst.func();
+  });
+})

--- a/packages/jimp/types/ts3.1/test.ts
+++ b/packages/jimp/types/ts3.1/test.ts
@@ -68,3 +68,21 @@ test('can clone properly', async () => {
     })
   })
 });
+
+test('Can handle callback with constructor', () => {
+  const myBmpBuffer: Buffer = {} as any;
+
+  Jimp.read(myBmpBuffer, (err, cbJimpInst) => {
+    cbJimpInst.read('Test');
+    cbJimpInst.displace(jimpInst, 2);
+    cbJimpInst.resize(40, 40);
+    // $ExpectType 0
+    cbJimpInst.PNG_FILTER_NONE;
+
+    // $ExpectError
+    cbJimpInst.test;
+
+    // $ExpectError
+    cbJimpInst.func();
+  });
+});


### PR DESCRIPTION
# What's Changing and Why

A minor bugfix to typings, it was originally reported in this comment https://github.com/oliver-moran/jimp/issues/803#issuecomment-542729706 that the `read` method callback was not typed properly. This is because the typing call was missing from the `0.6.4` typings. This PR adds them where expected and adds type tests to prevent future regression in this area

## Tasks

- [x] Add tests
- [x] Update `jimp.d.ts`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `0.8.6-canary.810.481.0`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
