### PR TITLE
Update core-js@^3.1.4

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -6,7 +6,8 @@ module.exports = api => {
       [
         '@babel/env',
         {
-          useBuiltIns: 'usage'
+          useBuiltIns: 'usage',
+          corejs: '3.1.4'
         }
       ]
     ],

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -37,7 +37,7 @@
     "@jimp/utils": "^0.8.5",
     "any-base": "^1.1.0",
     "buffer": "^5.2.0",
-    "core-js": "^2.5.7",
+    "core-js": "^3.4.1",
     "exif-parser": "^0.1.12",
     "file-type": "^9.0.0",
     "load-bmfont": "^1.3.1",

--- a/packages/custom/package.json
+++ b/packages/custom/package.json
@@ -18,7 +18,7 @@
   "license": "MIT",
   "dependencies": {
     "@jimp/core": "^0.8.5",
-    "core-js": "^2.5.7"
+    "core-js": "^3.4.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/jimp/package.json
+++ b/packages/jimp/package.json
@@ -62,7 +62,7 @@
     "@jimp/custom": "^0.8.5",
     "@jimp/plugins": "^0.8.5",
     "@jimp/types": "^0.8.5",
-    "core-js": "^2.5.7",
+    "core-js": "^3.4.1",
     "regenerator-runtime": "^0.13.3"
   },
   "devDependencies": {

--- a/packages/plugin-blit/package.json
+++ b/packages/plugin-blit/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "dependencies": {
     "@jimp/utils": "^0.8.5",
-    "core-js": "^2.5.7"
+    "core-js": "^3.4.1"
   },
   "devDependencies": {
     "@jimp/custom": "^0.8.5",

--- a/packages/plugin-blur/package.json
+++ b/packages/plugin-blur/package.json
@@ -18,7 +18,7 @@
   "license": "MIT",
   "dependencies": {
     "@jimp/utils": "^0.8.5",
-    "core-js": "^2.5.7"
+    "core-js": "^3.4.1"
   },
   "peerDependencies": {
     "@jimp/custom": ">=0.3.5"

--- a/packages/plugin-circle/package.json
+++ b/packages/plugin-circle/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "dependencies": {
     "@jimp/utils": "^0.8.5",
-    "core-js": "^2.5.7"
+    "core-js": "^3.4.1"
   },
   "peerDependencies": {
     "@jimp/custom": ">=0.3.5"

--- a/packages/plugin-color/package.json
+++ b/packages/plugin-color/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "dependencies": {
     "@jimp/utils": "^0.8.5",
-    "core-js": "^2.5.7",
+    "core-js": "^3.4.1",
     "tinycolor2": "^1.4.1"
   },
   "devDependencies": {

--- a/packages/plugin-contain/package.json
+++ b/packages/plugin-contain/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "dependencies": {
     "@jimp/utils": "^0.8.5",
-    "core-js": "^2.5.7"
+    "core-js": "^3.4.1"
   },
   "peerDependencies": {
     "@jimp/custom": ">=0.3.5",

--- a/packages/plugin-cover/package.json
+++ b/packages/plugin-cover/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "dependencies": {
     "@jimp/utils": "^0.8.5",
-    "core-js": "^2.5.7"
+    "core-js": "^3.4.1"
   },
   "peerDependencies": {
     "@jimp/custom": ">=0.3.5",

--- a/packages/plugin-crop/package.json
+++ b/packages/plugin-crop/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "dependencies": {
     "@jimp/utils": "^0.8.5",
-    "core-js": "^2.5.7"
+    "core-js": "^3.4.1"
   },
   "devDependencies": {
     "@jimp/custom": "^0.8.5",

--- a/packages/plugin-displace/package.json
+++ b/packages/plugin-displace/package.json
@@ -18,7 +18,7 @@
   "license": "MIT",
   "dependencies": {
     "@jimp/utils": "^0.8.5",
-    "core-js": "^2.5.7"
+    "core-js": "^3.4.1"
   },
   "peerDependencies": {
     "@jimp/custom": ">=0.3.5"

--- a/packages/plugin-dither/package.json
+++ b/packages/plugin-dither/package.json
@@ -18,7 +18,7 @@
   "license": "MIT",
   "dependencies": {
     "@jimp/utils": "^0.8.5",
-    "core-js": "^2.5.7"
+    "core-js": "^3.4.1"
   },
   "peerDependencies": {
     "@jimp/custom": ">=0.3.5"

--- a/packages/plugin-fisheye/package.json
+++ b/packages/plugin-fisheye/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "dependencies": {
     "@jimp/utils": "^0.8.5",
-    "core-js": "^2.5.7"
+    "core-js": "^3.4.1"
   },
   "peerDependencies": {
     "@jimp/custom": ">=0.3.5"

--- a/packages/plugin-flip/package.json
+++ b/packages/plugin-flip/package.json
@@ -18,7 +18,7 @@
   "license": "MIT",
   "dependencies": {
     "@jimp/utils": "^0.8.5",
-    "core-js": "^2.5.7"
+    "core-js": "^3.4.1"
   },
   "peerDependencies": {
     "@jimp/custom": ">=0.3.5",

--- a/packages/plugin-gaussian/package.json
+++ b/packages/plugin-gaussian/package.json
@@ -18,7 +18,7 @@
   "license": "MIT",
   "dependencies": {
     "@jimp/utils": "^0.8.5",
-    "core-js": "^2.5.7"
+    "core-js": "^3.4.1"
   },
   "peerDependencies": {
     "@jimp/custom": ">=0.3.5"

--- a/packages/plugin-invert/package.json
+++ b/packages/plugin-invert/package.json
@@ -18,7 +18,7 @@
   "license": "MIT",
   "dependencies": {
     "@jimp/utils": "^0.8.5",
-    "core-js": "^2.5.7"
+    "core-js": "^3.4.1"
   },
   "peerDependencies": {
     "@jimp/custom": ">=0.3.5"

--- a/packages/plugin-mask/package.json
+++ b/packages/plugin-mask/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "dependencies": {
     "@jimp/utils": "^0.8.5",
-    "core-js": "^2.5.7"
+    "core-js": "^3.4.1"
   },
   "peerDependencies": {
     "@jimp/custom": ">=0.3.5"

--- a/packages/plugin-normalize/package.json
+++ b/packages/plugin-normalize/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "dependencies": {
     "@jimp/utils": "^0.8.5",
-    "core-js": "^2.5.7"
+    "core-js": "^3.4.1"
   },
   "peerDependencies": {
     "@jimp/custom": ">=0.3.5"

--- a/packages/plugin-print/package.json
+++ b/packages/plugin-print/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "dependencies": {
     "@jimp/utils": "^0.8.5",
-    "core-js": "^2.5.7",
+    "core-js": "^3.4.1",
     "load-bmfont": "^1.4.0"
   },
   "peerDependencies": {

--- a/packages/plugin-resize/package.json
+++ b/packages/plugin-resize/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "dependencies": {
     "@jimp/utils": "^0.8.5",
-    "core-js": "^2.5.7"
+    "core-js": "^3.4.1"
   },
   "peerDependencies": {
     "@jimp/custom": ">=0.3.5"

--- a/packages/plugin-rotate/package.json
+++ b/packages/plugin-rotate/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "dependencies": {
     "@jimp/utils": "^0.8.5",
-    "core-js": "^2.5.7"
+    "core-js": "^3.4.1"
   },
   "peerDependencies": {
     "@jimp/custom": ">=0.3.5",

--- a/packages/plugin-scale/package.json
+++ b/packages/plugin-scale/package.json
@@ -18,7 +18,7 @@
   "license": "MIT",
   "dependencies": {
     "@jimp/utils": "^0.8.5",
-    "core-js": "^2.5.7"
+    "core-js": "^3.4.1"
   },
   "peerDependencies": {
     "@jimp/custom": ">=0.3.5",

--- a/packages/plugin-shadow/package.json
+++ b/packages/plugin-shadow/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "dependencies": {
     "@jimp/utils": "^0.8.5",
-    "core-js": "^2.5.7"
+    "core-js": "^3.4.1"
   },
   "peerDependencies": {
     "@jimp/custom": ">=0.3.5",

--- a/packages/plugin-threshold/package.json
+++ b/packages/plugin-threshold/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "dependencies": {
     "@jimp/utils": "^0.8.5",
-    "core-js": "^2.5.7"
+    "core-js": "^3.4.1"
   },
   "peerDependencies": {
     "@jimp/custom": ">=0.3.5",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -34,7 +34,7 @@
     "@jimp/plugin-resize": "^0.8.5",
     "@jimp/plugin-rotate": "^0.8.5",
     "@jimp/plugin-scale": "^0.8.5",
-    "core-js": "^2.5.7",
+    "core-js": "^3.4.1",
     "timm": "^1.6.1"
   },
   "peerDependencies": {

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -22,7 +22,7 @@
     "access": "public"
   },
   "dependencies": {
-    "core-js": "^2.5.7",
+    "core-js": "^3.4.1",
     "pngjs": "^3.3.3"
   },
   "devDependencies": {

--- a/packages/type-bmp/package.json
+++ b/packages/type-bmp/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@jimp/utils": "^0.8.5",
     "bmp-js": "^0.1.0",
-    "core-js": "^2.5.7"
+    "core-js": "^3.4.1"
   },
   "peerDependencies": {
     "@jimp/custom": ">=0.3.5"

--- a/packages/type-gif/package.json
+++ b/packages/type-gif/package.json
@@ -18,7 +18,7 @@
   "license": "MIT",
   "dependencies": {
     "@jimp/utils": "^0.8.5",
-    "core-js": "^2.5.7",
+    "core-js": "^3.4.1",
     "omggif": "^1.0.9"
   },
   "peerDependencies": {

--- a/packages/type-jpeg/package.json
+++ b/packages/type-jpeg/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "dependencies": {
     "@jimp/utils": "^0.8.5",
-    "core-js": "^2.5.7",
+    "core-js": "^3.4.1",
     "jpeg-js": "^0.3.4"
   },
   "peerDependencies": {

--- a/packages/type-png/package.json
+++ b/packages/type-png/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "dependencies": {
     "@jimp/utils": "^0.8.5",
-    "core-js": "^2.5.7",
+    "core-js": "^3.4.1",
     "pngjs": "^3.3.3"
   },
   "peerDependencies": {

--- a/packages/type-tiff/package.json
+++ b/packages/type-tiff/package.json
@@ -20,7 +20,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "core-js": "^2.5.7",
+    "core-js": "^3.4.1",
     "utif": "^2.0.1"
   },
   "peerDependencies": {

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -22,7 +22,7 @@
     "@jimp/jpeg": "^0.8.5",
     "@jimp/png": "^0.8.5",
     "@jimp/tiff": "^0.8.5",
-    "core-js": "^2.5.7",
+    "core-js": "^3.4.1",
     "timm": "^1.6.1"
   },
   "peerDependencies": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -20,6 +20,6 @@
     "access": "public"
   },
   "dependencies": {
-    "core-js": "^2.5.7"
+    "core-js": "^3.4.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3221,14 +3221,15 @@ core-js@^2.0.0:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.9.tgz#6b4b214620c834152e179323727fc19741b084f2"
   integrity sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==
 
-core-js@^2.5.7:
-  version "2.5.7"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.7.tgz#f972608ff0cead68b841a16a932d0b183791814e"
-
 core-js@^3.1.3:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.2.1.tgz#cd41f38534da6cc59f7db050fe67307de9868b09"
   integrity sha512-Qa5XSVefSVPRxy2XfUC13WbvqkxhkwB3ve+pgCQveNgYzbM/UxZeu1dcOX/xr4UmfUd+muuvsaxilQzCyUurMw==
+
+core-js@^3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.4.1.tgz#76dd6828412900ab27c8ce0b22e6114d7ce21b18"
+  integrity sha512-KX/dnuY/J8FtEwbnrzmAjUYgLqtk+cxM86hfG60LGiW3MmltIc2yAmDgBgEkfm0blZhUrdr1Zd84J2Y14mLxzg==
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"


### PR DESCRIPTION
# What's Changing and Why

Upgrade core-js as recommended by the `yarn install` warnings. 
This also required to specify the core-js version in the babel config for tests to run, as the version 2 is assumed according to babel logs:

```
WARNING: We noticed you're using the `useBuiltIns` option without declaring a core-js version. Currently, we assume version 2.x when no version is passed. Since this default version will likely change in future versions of Babel, we recommend explicitly setting the core-js version you are using via the `corejs` option.
```

See https://github.com/oliver-moran/jimp/issues/817 for more information about this problem.

## What else might be affected

I must admit I have not digged through the change between core-js@2 and core-js@3.XX. If they changed the major version number, some things must have broke, but I don't know which and which are used by jimp.

## Tasks

- [ ] Add tests
- [ ] Update Documentation
- [ ] Update `jimp.d.ts`
- [ ] Add [SemVer](https://semver.org/) Label

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `0.8.6-canary.818.495.0`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
