### PR TITLE
Revert exports to match 0.6.4 TS definitions

### DIFF
--- a/packages/jimp/types/index.d.ts
+++ b/packages/jimp/types/index.d.ts
@@ -3,7 +3,7 @@
 
 declare const DepreciatedJimp: DepreciatedJimp;
 
-export default DepreciatedJimp;
+export = DepreciatedJimp;
 
 /**
  * @deprecated Jimp typings for TS <3.1 are being depreciated. Please upgrade your TypeScript version
@@ -500,7 +500,7 @@ type URLOptions = {
 /**
  * @deprecated Jimp typings for TS <3.1 are being depreciated. Please upgrade your TypeScript version
  */
-export interface Bitmap {
+interface Bitmap {
   data: Buffer;
   width: number;
   height: number;
@@ -508,7 +508,7 @@ export interface Bitmap {
 /**
  * @deprecated Jimp typings for TS <3.1 are being depreciated. Please upgrade your TypeScript version
  */
-export interface RGB {
+interface RGB {
   r: number;
   g: number;
   b: number;
@@ -517,7 +517,7 @@ export interface RGB {
 /**
  * @deprecated Jimp typings for TS <3.1 are being depreciated. Please upgrade your TypeScript version
  */
-export interface RGBA {
+interface RGBA {
   r: number;
   g: number;
   b: number;
@@ -527,7 +527,7 @@ export interface RGBA {
 /**
  * @deprecated Jimp typings for TS <3.1 are being depreciated. Please upgrade your TypeScript version
  */
-export interface FontChar {
+interface FontChar {
   id: number;
   x: number;
   y: number;
@@ -543,7 +543,7 @@ export interface FontChar {
 /**
  * @deprecated Jimp typings for TS <3.1 are being depreciated. Please upgrade your TypeScript version
  */
-export interface FontInfo {
+interface FontInfo {
   face: string;
   size: number;
   bold: number;
@@ -560,7 +560,7 @@ export interface FontInfo {
 /**
  * @deprecated Jimp typings for TS <3.1 are being depreciated. Please upgrade your TypeScript version
  */
-export interface FontCommon {
+interface FontCommon {
   lineHeight: number;
   base: number;
   scaleW: number;
@@ -576,7 +576,7 @@ export interface FontCommon {
 /**
  * @deprecated Jimp typings for TS <3.1 are being depreciated. Please upgrade your TypeScript version
  */
-export interface Font {
+interface Font {
   chars: {
     [char: string]: FontChar;
   };

--- a/packages/jimp/types/test.ts
+++ b/packages/jimp/types/test.ts
@@ -1,4 +1,4 @@
-import Jimp from 'jimp';
+import * as Jimp from 'jimp';
 
 const jimpInst: Jimp = new Jimp('test');
 

--- a/packages/jimp/types/ts3.1/index.d.ts
+++ b/packages/jimp/types/ts3.1/index.d.ts
@@ -20,10 +20,6 @@ import pluginFn from '@jimp/plugins';
 type Types = ReturnType<typeof typeFn>;
 type Plugins = ReturnType<typeof pluginFn>;
 
-export { Bitmap, RGB, RGBA };
-
-export { FontChar, FontInfo, FontCommon, Font } from '@jimp/plugin-print';
-
 type IntersectedPluginTypes = UnionToIntersection<
   GetPluginVal<Types> | GetPluginVal<Plugins>
 >;
@@ -32,4 +28,4 @@ type Jimp = InstanceType<JimpType> & IntersectedPluginTypes;
 
 declare const Jimp: JimpConstructors & Jimp;
 
-export default Jimp;
+export = Jimp;

--- a/packages/jimp/types/ts3.1/test.ts
+++ b/packages/jimp/types/ts3.1/test.ts
@@ -1,4 +1,4 @@
-import Jimp from 'jimp';
+import * as Jimp from 'jimp';
 
 const jimpInst: Jimp = new Jimp('test');
 


### PR DESCRIPTION
# What's Changing and Why

Many developers using TypeScript have reported that 0.6.4 was the last time that they were able to use the TypeScript definition files. This is because in 0.6.5 the `export` format was modified to more accurately fall inline with ESModule export syntax. 

While TypeScript compiler, with some settings, allow you to handle this export and have the correct results, if the project feels it better to use the same exports as 0.6.4, this is how it would be done without removing the additional types from missing plugins, removing the TS type tests, and more

## What else might be affected

This would be a breaking change from the current (or even the version 0.6.5) definition files as we no longer export interfaces such as `Bitmap` or others. This is because this `export = Object` does not allow for any other exports to be named in a definition file. Needless to say, _someone_ is not going to be happy with the typings regardless of what we do. I'm just opening this PR per https://github.com/oliver-moran/jimp/issues/803#issuecomment-556872322 as it seems like _this_ is the direction we want to go in

## Tasks

- [x] Add tests
- [ ] Update Documentation
- [x] Update `jimp.d.ts`
- [ ] Add [SemVer](https://semver.org/) Label
