### PR TITLE
Update plugin-shadow type definition.

### DIFF
--- a/packages/plugin-shadow/index.d.ts
+++ b/packages/plugin-shadow/index.d.ts
@@ -4,6 +4,7 @@ interface Shadow {
   shadow(options?: {
            size?: number,
            opacity?: number,
+           blur: number,
            x?: number,
            y?: number
          },


### PR DESCRIPTION
# What's Changing and Why

The source code supports blur, the type defintion did not.

## What else might be affected

## Tasks

- [ ] Add tests
- [ ] Update Documentation
- [ ] Update `jimp.d.ts`
- [ ] Add [SemVer](https://semver.org/) Label

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `0.9.4-canary.841.620.0`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
