### PR TITLE
Fix vulnerability by updating mkdirp

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -42,7 +42,7 @@
     "exif-parser": "^0.1.12",
     "file-type": "^9.0.0",
     "load-bmfont": "^1.3.1",
-    "mkdirp": "0.5.1",
+    "mkdirp": "^1.0.3",
     "phin": "^2.9.1",
     "pixelmatch": "^4.0.2",
     "tinycolor2": "^1.4.1"


### PR DESCRIPTION
# What's Changing and Why
There is a prototype pollution vulnerability in minimist 0.0.8, used by mkdirp 0.5.1.
https://www.npmjs.com/advisories/1179

I suggest updating mkdirp to ^1.0.3, the latest version, which does not depend on minimist at all.

## What else might be affected
As the only thing we use from mkdirp is `mkdirp.sync`, and it is still seen in the latest mkdirp, I think it is safe to update mkdirp without breaking anything.

## Tasks

- [ ] Add tests
- [ ] Update Documentation
- [ ] Update `jimp.d.ts`
- [ ] Add [SemVer](https://semver.org/) Label
