### PR TITLE
Relax mkdirp dependency to allow newer minimist

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -42,7 +42,7 @@
     "exif-parser": "^0.1.12",
     "file-type": "^9.0.0",
     "load-bmfont": "^1.3.1",
-    "mkdirp": "0.5.1",
+    "mkdirp": "^0.5.1",
     "phin": "^2.9.1",
     "pixelmatch": "^4.0.2",
     "tinycolor2": "^1.4.1"


### PR DESCRIPTION
# What's Changing and Why
Fixing https://www.npmjs.com/advisories/1179 by relaxing mkdirp versions range to allow 0.5.2 or 0.5.3 which contains a fix as per https://github.com/isaacs/node-mkdirp/issues/7#issuecomment-600231795

## What else might be affected
Nothing 

## Tasks

- [ ] Add tests
- [ ] Update Documentation
- [ ] Update `jimp.d.ts`
- [ ] Add [SemVer](https://semver.org/) Label

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `0.9.6-canary.857.681.0`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
