### PR TITLE
Fix TypeScript error on 'next'

### DIFF
--- a/packages/core/types/jimp.d.ts
+++ b/packages/core/types/jimp.d.ts
@@ -170,14 +170,19 @@ export interface Jimp extends JimpConstructors {
   ): this;
 
   // Functions
-  appendConstructorOption<T extends any[]>(
+  /**
+   * I'd like to make `Args` generic and used in `run` and `test` but alas,
+   * it's not possible RN:
+   * https://github.com/microsoft/TypeScript/issues/26113
+   */
+  appendConstructorOption<Args extends any[], J extends Jimp = this>(
     name: string,
-    test: (...args: T[]) => boolean,
+    test: (...args: any[]) => boolean,
     run: (
-      this: this,
-      resolve: (jimp: this) => any,
+      this: J,
+      resolve: (jimp?: J) => any,
       reject: (reason: Error) => any,
-      ...args: T[]
+      ...args: any[]
     ) => any
   ): void;
   read(path: string, cb?: ImageCallback<this>): Promise<this>;

--- a/packages/core/types/utils.d.ts
+++ b/packages/core/types/utils.d.ts
@@ -13,8 +13,8 @@ export type UnionToIntersection<U> =
  * Left loose as "any" in order to enable the GetPluginValue to work properly
  */
 export type WellFormedValues<T extends any> = 
-  T['class'] &
-  T['constants'];
+  (T extends {class: any} ? T['class'] : {}) &
+  (T extends {constants: any} ? T['constants'] : {});
 
 // Util type for the functions that deal with `@jimp/custom`
 // Must accept any or no props thanks to typing of the `plugins` intersected function

--- a/packages/custom/types/test.ts
+++ b/packages/custom/types/test.ts
@@ -6,6 +6,7 @@ import resize from '@jimp/plugin-resize';
 import scale from '@jimp/plugin-scale';
 import types from '@jimp/types';
 import plugins from '@jimp/plugins';
+import * as Jimp from 'jimp';
 
 // configure should return a valid Jimp type with addons
 const CustomJimp = configure({
@@ -349,4 +350,21 @@ test('can handle only one plugin', () => {
 
   // $ExpectError
   Jiimp.func();
+});
+
+
+test('Can handle appendConstructorOption', () => {
+  const AppendJimp = configure({});
+
+  AppendJimp.appendConstructorOption(
+    'Name of Option',
+    args => args.hasSomeCustomThing,
+    function(resolve, reject, args) {
+      // $ExpectError
+      this.bitmap = 3;
+      // $ExpectError
+      AppendJimp.resize(2, 2);
+      resolve();
+    }
+  );
 });

--- a/packages/jimp/types/index.d.ts
+++ b/packages/jimp/types/index.d.ts
@@ -341,14 +341,19 @@ interface DepreciatedJimp {
   mask(src: this, x: number, y: number, cb?: ImageCallback): this;
 
   // Functions
-  appendConstructorOption<T extends any[]>(
+  /**
+   * I'd like to make `Args` generic and used in `run` and `test` but alas,
+   * it's not possible RN:
+   * https://github.com/microsoft/TypeScript/issues/26113
+   */
+  appendConstructorOption<Args extends any[]>(
     name: string,
-    test: (...args: T[]) => boolean,
+    test: (...args: any[]) => boolean,
     run: (
       this: this,
-      resolve: (jimp: this) => any,
+      resolve: (jimp?: this) => any,
       reject: (reason: Error) => any,
-      ...args: T[]
+      ...args: any[]
     ) => any
   ): void;
   read(path: string, cb?: ImageCallback): Promise<this>;

--- a/packages/jimp/types/test.ts
+++ b/packages/jimp/types/test.ts
@@ -86,3 +86,16 @@ test('Can handle callback with constructor', () => {
     cbJimpInst.func();
   });
 })
+
+test('Can handle appendConstructorOption', () => {
+  Jimp.appendConstructorOption(
+    'Name of Option',
+    args => args.hasSomeCustomThing,
+    function(resolve, reject, args) {
+      // $ExpectError
+      this.bitmap = 3;
+      Jimp.resize(2, 2);
+      resolve();
+    }
+  );
+});


### PR DESCRIPTION
# What's Changing and Why

TS tests seem to be failing in #857. I am unable to recreate this issue on my local machine, but I'm hoping this fixes it on CI (I think my local machine simply isn't getting `next` on TS properly)

## What else might be affected

## Tasks

- [ ] Add tests
- [ ] Update Documentation
- [x] Update `jimp.d.ts`
- [ ] Add [SemVer](https://semver.org/) Label

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `0.9.6-canary.858.667.0`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
