### PR TITLE
Relax version range of plugin-threshold peerDependencies

### DIFF
--- a/packages/plugin-threshold/package.json
+++ b/packages/plugin-threshold/package.json
@@ -26,8 +26,8 @@
   },
   "peerDependencies": {
     "@jimp/custom": ">=0.3.5",
-    "@jimp/plugin-color": "^0.8.0",
-    "@jimp/plugin-resize": "^0.8.0"
+    "@jimp/plugin-color": ">=0.8.0",
+    "@jimp/plugin-resize": ">=0.8.0"
   },
   "devDependencies": {
     "@jimp/custom": "link:../custom",


### PR DESCRIPTION
# What's Changing and Why

The threshold plugin has peer dependencies color/resize plugins `^0.8.0`, which does not match `0.9.5`, and install from scratch complains:

    $ npm install @jimp/plugin-threshold @jimp/plugin-color @jimp/plugin-resize @jimp/custom
    npm WARN @jimp/plugin-threshold@0.9.5 requires a peer of @jimp/plugin-color@^0.8.0 but none is installed. You must install peer dependencies yourself.
    npm WARN @jimp/plugin-threshold@0.9.5 requires a peer of @jimp/plugin-resize@^0.8.0 but none is installed. You must install peer dependencies yourself.

This PR changes the peer dependency version to `>0.8.0`.

## What else might be affected

## Tasks

- [ ] Add tests
- [ ] Update Documentation
- [ ] Update `jimp.d.ts`
- [ ] Add [SemVer](https://semver.org/) Label
