### PR TITLE
Added missing plugins to the types

### DIFF
--- a/packages/jimp/types/test.ts
+++ b/packages/jimp/types/test.ts
@@ -18,6 +18,7 @@ jimpInst.func();
 // Main Jimp export should already have all of these already applied
 Jimp.read('Test');
 Jimp.displace(Jimp, 2);
+Jimp.shadow((err, val, coords) => {});
 Jimp.resize(40, 40);
 // $ExpectType 0
 Jimp.PNG_FILTER_NONE;

--- a/packages/jimp/types/ts3.1/test.ts
+++ b/packages/jimp/types/ts3.1/test.ts
@@ -18,6 +18,10 @@ jimpInst.func();
 // Main Jimp export should already have all of these already applied
 Jimp.read('Test');
 Jimp.displace(Jimp, 2);
+Jimp.shadow((err, val, coords) => {});
+Jimp.fishEye({r: 12});
+Jimp.circle({radius: 12, x: 12, y: 12});
+
 Jimp.resize(40, 40);
 // $ExpectType 0
 Jimp.PNG_FILTER_NONE;

--- a/packages/plugins/index.d.ts
+++ b/packages/plugins/index.d.ts
@@ -1,38 +1,46 @@
-import dither from '@jimp/plugin-dither';
-import resize from '@jimp/plugin-resize';
 import blit from '@jimp/plugin-blit';
-import rotate from '@jimp/plugin-rotate';
-import color from '@jimp/plugin-color';
-import print from '@jimp/plugin-print';
 import blur from '@jimp/plugin-blur';
-import crop from '@jimp/plugin-crop';
-import normalize from '@jimp/plugin-normalize';
-import invert from '@jimp/plugin-invert';
-import gaussian from '@jimp/plugin-gaussian';
-import flip from '@jimp/plugin-flip';
-import mask from '@jimp/plugin-mask';
-import scale from '@jimp/plugin-scale';
-import displace from '@jimp/plugin-displace';
+import circle from '@jimp/plugin-circle';
+import color from '@jimp/plugin-color';
 import contain from '@jimp/plugin-contain';
 import cover from '@jimp/plugin-cover';
+import crop from '@jimp/plugin-crop';
+import displace from '@jimp/plugin-displace';
+import dither from '@jimp/plugin-dither';
+import fisheye from '@jimp/plugin-fisheye';
+import flip from '@jimp/plugin-flip';
+import gaussian from '@jimp/plugin-gaussian';
+import invert from '@jimp/plugin-invert';
+import mask from '@jimp/plugin-mask';
+import normalize from '@jimp/plugin-normalize';
+import print from '@jimp/plugin-print';
+import resize from '@jimp/plugin-resize';
+import rotate from '@jimp/plugin-rotate';
+import scale from '@jimp/plugin-scale';
+import shadow from '@jimp/plugin-shadow';
+import threshold from '@jimp/plugin-threshold';
 
-type DitherRet = ReturnType<typeof dither>
-type ResizeRet = ReturnType<typeof resize>
-type BlitRet = ReturnType<typeof blit>
-type RotateRet = ReturnType<typeof rotate>
-type ColorRet = ReturnType<typeof color>
-type PrintRet = ReturnType<typeof print>
-type BlurRet = ReturnType<typeof blur>
-type CropRet = ReturnType<typeof crop>
-type NormalizeRet = ReturnType<typeof normalize>
-type InvertRet = ReturnType<typeof invert>
-type GaussianRet = ReturnType<typeof gaussian>
-type FlipRet = ReturnType<typeof flip>
-type MaskRet = ReturnType<typeof mask>
-type ScaleRet = ReturnType<typeof scale>
-type DisplaceRet = ReturnType<typeof displace>
-type ContainRet = ReturnType<typeof contain>
-type CoverRet = ReturnType<typeof cover>
+type BlitRet = ReturnType<typeof blit>;
+type BlurRet = ReturnType<typeof blur>;
+type CircleRet = ReturnType<typeof circle>;
+type ColorRet = ReturnType<typeof color>;
+type ContainRet = ReturnType<typeof contain>;
+type CoverRet = ReturnType<typeof cover>;
+type CropRet = ReturnType<typeof crop>;
+type DisplaceRet = ReturnType<typeof displace>;
+type DitherRet = ReturnType<typeof dither>;
+type FlipRet = ReturnType<typeof flip>;
+type FisheyeRet = ReturnType<typeof fisheye>;
+type GaussianRet = ReturnType<typeof gaussian>;
+type InvertRet = ReturnType<typeof invert>;
+type MaskRet = ReturnType<typeof mask>;
+type NormalizeRet = ReturnType<typeof normalize>;
+type PrintRet = ReturnType<typeof print>;
+type ResizeRet = ReturnType<typeof resize>;
+type RotateRet = ReturnType<typeof rotate>;
+type ScaleRet = ReturnType<typeof scale>;
+type ShadowRet = ReturnType<typeof shadow>;
+type ThresholdRet = ReturnType<typeof threshold>;
 
 /**
  * This is made union and not intersection to avoid issues with
@@ -42,22 +50,27 @@ type CoverRet = ReturnType<typeof cover>
  * In reality, this should be an intersection but our type data isn't
  * clever enough to figure out what's a class and what's not/etc
  */
-type Plugins = DitherRet |
-  ResizeRet |
-  BlitRet |
-  RotateRet |
-  ColorRet |
-  PrintRet |
-  BlurRet |
-  CropRet |
-  NormalizeRet |
-  InvertRet |
-  GaussianRet |
-  FlipRet |
-  MaskRet |
-  ScaleRet |
-  DisplaceRet |
-  ContainRet |
-  CoverRet;
+type Plugins =
+  | BlitRet
+  | BlurRet
+  | CircleRet
+  | ColorRet
+  | ContainRet
+  | CoverRet
+  | CropRet
+  | DisplaceRet
+  | DitherRet
+  | FlipRet
+  | FisheyeRet
+  | GaussianRet
+  | InvertRet
+  | MaskRet
+  | NormalizeRet
+  | PrintRet
+  | ResizeRet
+  | RotateRet
+  | ScaleRet
+  | ShadowRet
+  | ThresholdRet;
 
 export default function(): Plugins;


### PR DESCRIPTION
# What's Changing and Why

As mentioned by @SaliZumberi during a discussion on #689, I noticed we were missing a few plugins from the core typings for typings versions 3.1+. This PR adds those plugins and the typings associated

## What else might be affected

This should be a minor release as it doesn't break any functionality

## Tasks

- [x] Add tests
- [ ] Update Documentation
- [x] Update `jimp.d.ts`
- [ ] Add [SemVer](https://semver.org/) Label
