### PR TITLE
Properly split constructor and instance types

### DIFF
--- a/packages/core/types/jimp.d.ts
+++ b/packages/core/types/jimp.d.ts
@@ -23,24 +23,7 @@ interface ScanIteratorReturn<This> {
 }
 
 export interface JimpConstructors {
-  new(path: string, cb?: ImageCallback<this>): this;
-  new(urlOptions: URLOptions, cb?: ImageCallback<this>): this;
-  new(image: Jimp, cb?: ImageCallback<this>): this;
-  new(data: Buffer, cb?: ImageCallback<this>): this;
-  new(data: Bitmap, cb?: ImageCallback<this>): this;
-  new(w: number, h: number, cb?: ImageCallback<this>): this;
-  new(
-    w: number,
-    h: number,
-    background?: number | string,
-    cb?: ImageCallback<this>
-  ): this;
-  // For custom constructors when using Jimp.appendConstructorOption
-  new(...args: any[]): this;
-}
-
-export interface Jimp extends JimpConstructors {
-  prototype: this;
+  prototype: Jimp;
   // Constants
   AUTO: -1;
   // blend modes
@@ -65,6 +48,70 @@ export interface Jimp extends JimpConstructors {
   EDGE_EXTEND: 1;
   EDGE_WRAP: 2;
   EDGE_CROP: 3;
+
+  // Constructors
+  new(path: string, cb?: ImageCallback<this['prototype']>): this['prototype'];
+  new(urlOptions: URLOptions, cb?: ImageCallback<this['prototype']>): this['prototype'];
+  new(image: Jimp, cb?: ImageCallback<this['prototype']>): this['prototype'];
+  new(data: Buffer, cb?: ImageCallback<this['prototype']>): this['prototype'];
+  new(data: Bitmap, cb?: ImageCallback<this['prototype']>): this['prototype'];
+  new(w: number, h: number, cb?: ImageCallback<this['prototype']>): this['prototype'];
+  new(
+    w: number,
+    h: number,
+    background?: number | string,
+    cb?: ImageCallback<this['prototype']>
+  ): this['prototype'];
+  // For custom constructors when using Jimp.appendConstructorOption
+  new(...args: any[]): this['prototype'];
+
+  // Functions
+  /**
+   * I'd like to make `Args` generic and used in `run` and `test` but alas,
+   * it's not possible RN:
+   * https://github.com/microsoft/TypeScript/issues/26113
+   */
+  appendConstructorOption<Args extends any[], J extends Jimp = this['prototype']>(
+    name: string,
+    test: (...args: any[]) => boolean,
+    run: (
+      this: J,
+      resolve: (jimp?: J) => any,
+      reject: (reason: Error) => any,
+      ...args: any[]
+    ) => any
+  ): void;
+  read(path: string, cb?: ImageCallback<this['prototype']>): Promise<this['prototype']>;
+  read(image: Jimp, cb?: ImageCallback<this['prototype']>): Promise<this['prototype']>;
+  read(data: Buffer, cb?: ImageCallback<this['prototype']>): Promise<this['prototype']>;
+  read(
+    w: number,
+    h: number,
+    background?: number | string,
+    cb?: ImageCallback<this['prototype']>
+  ): Promise<this['prototype']>;
+  create(path: string): Promise<this['prototype']>;
+  create(image: Jimp): Promise<this['prototype']>;
+  create(data: Buffer): Promise<this['prototype']>;
+  create(w: number, h: number, background?: number | string): Promise<this['prototype']>;
+  rgbaToInt(
+    r: number,
+    g: number,
+    b: number,
+    a: number,
+    cb: GenericCallback<number, any, this['prototype']>
+  ): number;
+  intToRGBA(i: number, cb?: GenericCallback<RGBA>): RGBA;
+  cssColorToHex(cssColor: string): number;
+  limit255(n: number): number;
+  diff(img1: Jimp, img2: Jimp, threshold?: number): DiffReturn<this['prototype']>;
+  distance(img1: Jimp, img2: Jimp): number;
+  compareHashes(hash1: string, hash2: string): number;
+  colorDiff(rgba1: RGB, rgba2: RGB): number;
+  colorDiff(rgba1: RGBA, rgba2: RGBA): number;
+}
+
+export interface Jimp {
   // Properties
   bitmap: Bitmap;
   _rgba: boolean;
@@ -168,49 +215,4 @@ export interface Jimp extends JimpConstructors {
     options?: BlendMode,
     cb?: ImageCallback<this>
   ): this;
-
-  // Functions
-  /**
-   * I'd like to make `Args` generic and used in `run` and `test` but alas,
-   * it's not possible RN:
-   * https://github.com/microsoft/TypeScript/issues/26113
-   */
-  appendConstructorOption<Args extends any[], J extends Jimp = this>(
-    name: string,
-    test: (...args: any[]) => boolean,
-    run: (
-      this: J,
-      resolve: (jimp?: J) => any,
-      reject: (reason: Error) => any,
-      ...args: any[]
-    ) => any
-  ): void;
-  read(path: string, cb?: ImageCallback<this>): Promise<this>;
-  read(image: Jimp, cb?: ImageCallback<this>): Promise<this>;
-  read(data: Buffer, cb?: ImageCallback<this>): Promise<this>;
-  read(
-    w: number,
-    h: number,
-    background?: number | string,
-    cb?: ImageCallback<this>
-  ): Promise<this>;
-  create(path: string): Promise<this>;
-  create(image: Jimp): Promise<this>;
-  create(data: Buffer): Promise<this>;
-  create(w: number, h: number, background?: number | string): Promise<this>;
-  rgbaToInt(
-    r: number,
-    g: number,
-    b: number,
-    a: number,
-    cb: GenericCallback<number, any, this>
-  ): number;
-  intToRGBA(i: number, cb?: GenericCallback<RGBA>): RGBA;
-  cssColorToHex(cssColor: string): number;
-  limit255(n: number): number;
-  diff(img1: Jimp, img2: Jimp, threshold?: number): DiffReturn<this>;
-  distance(img1: Jimp, img2: Jimp): number;
-  compareHashes(hash1: string, hash2: string): number;
-  colorDiff(rgba1: RGB, rgba2: RGB): number;
-  colorDiff(rgba1: RGBA, rgba2: RGBA): number;
 }

--- a/packages/core/types/utils.d.ts
+++ b/packages/core/types/utils.d.ts
@@ -48,11 +48,11 @@ export type GetPluginEncoders<Q> = Q extends Required<{class: any}> | Required<{
 
 type GetPluginFuncArrValues<PluginFuncArr> =
   // Given an array of types infer `Q` (Q should be the type value)
-  PluginFuncArr extends ReadonlyArray<() => infer Q>
+  PluginFuncArr extends ReadonlyArray<infer F> ? F extends () => infer Q
   ? // Get the plugin value, may be ill-formed or well-formed
     GetPluginVal<Q>
   : // This should never be reached
-    undefined;
+    undefined : undefined;
 
 /**
  * A helper type to get the values to be intersected with `Jimp` to give
@@ -60,31 +60,31 @@ type GetPluginFuncArrValues<PluginFuncArr> =
  */
 export type GetIntersectionFromPlugins<
   PluginFuncArr extends FunctionRet<JimpPlugin | JimpType>
-> = UnionToIntersection<GetPluginFuncArrValues<PluginFuncArr>>;
+> = UnionToIntersection<Exclude<GetPluginFuncArrValues<PluginFuncArr>, undefined>>;
 
 type GetPluginFuncArrConsts<PluginFuncArr> =
   // Given an array of types infer `Q` (Q should be the type value)
-  PluginFuncArr extends ReadonlyArray<() => infer Q>
+  PluginFuncArr extends ReadonlyArray<infer F> ? F extends () => infer Q
   ? // Get the plugin constants, may be ill-formed or well-formed
     GetPluginConst<Q>
   : // This should never be reached
-    undefined;
+    undefined : undefined;
 
 type GetPluginFuncArrEncoders<PluginFuncArr> =
   // Given an array of types infer `Q` (Q should be the type value)
-  PluginFuncArr extends ReadonlyArray<() => infer Q>
+  PluginFuncArr extends ReadonlyArray<infer F> ? F extends () => infer Q
   ? // Get the plugin encoders, may be ill-formed or well-formed
     GetPluginEncoders<Q>
   : // This should never be reached
-    undefined;
+    undefined : undefined;
 
 type GetPluginFuncArrDecoders<PluginFuncArr> =
   // Given an array of types infer `Q` (Q should be the type value)
-  PluginFuncArr extends ReadonlyArray<() => infer Q>
+  PluginFuncArr extends ReadonlyArray<infer F> ? F extends () => infer Q
   ? // Get the plugin decoders, may be ill-formed or well-formed
     GetPluginDecoders<Q>
   : // This should never be reached
-    undefined;
+    undefined : undefined;
 
 /**
  * A helper type to get the statics to be intersected with `Jimp` to give

--- a/packages/core/types/utils.d.ts
+++ b/packages/core/types/utils.d.ts
@@ -10,17 +10,17 @@ export type UnionToIntersection<U> =
 
 /**
  * The values to be extracted from a WellFormedPlugin to put onto the Jimp instance
- * Left loose as "any" in order to enable the GetPluginValue to work properly
+ * Left loose as "any" in order to enable the GetPluginVal to work properly
  */
 export type WellFormedValues<T extends any> = 
-  (T extends {class: any} ? T['class'] : {});
+  (T extends {class: infer Class} ? Class : {});
 
 /**
  * The constants to be extracted from a WellFormedPlugin to put onto the Jimp instance
  * Left loose as "any" in order to enable the GetPluginConstants to work properly
  */
 export type WellFormedConstants<T extends any> =
-  (T extends {constants: any} ? T['constants'] : {});
+  (T extends {constants: infer Constants} ? Constants : {});
 
 // Util type for the functions that deal with `@jimp/custom`
 // Must accept any or no props thanks to typing of the `plugins` intersected function
@@ -39,6 +39,12 @@ export type GetPluginVal<Q> = Q extends Required<{class: any}> | Required<{const
 export type GetPluginConst<Q> = Q extends Required<{class: any}> | Required<{constants: any}>
   ? WellFormedConstants<Q>
   : {};
+
+export type GetPluginDecoders<Q> = Q extends Required<{class: any}> | Required<{constants: any}>
+  ? Q extends {decoders: infer Decoders} ? Decoders : {} : {};
+
+export type GetPluginEncoders<Q> = Q extends Required<{class: any}> | Required<{constants: any}>
+  ? Q extends {encoders: infer Encoders} ? Encoders : {} : {};
 
 type GetPluginFuncArrValues<PluginFuncArr> =
   // Given an array of types infer `Q` (Q should be the type value)

--- a/packages/core/types/utils.d.ts
+++ b/packages/core/types/utils.d.ts
@@ -48,7 +48,7 @@ export type GetPluginEncoders<Q> = Q extends Required<{class: any}> | Required<{
 
 type GetPluginFuncArrValues<PluginFuncArr> =
   // Given an array of types infer `Q` (Q should be the type value)
-  PluginFuncArr extends Array<() => infer Q>
+  PluginFuncArr extends ReadonlyArray<() => infer Q>
   ? // Get the plugin value, may be ill-formed or well-formed
     GetPluginVal<Q>
   : // This should never be reached
@@ -61,6 +61,41 @@ type GetPluginFuncArrValues<PluginFuncArr> =
 export type GetIntersectionFromPlugins<
   PluginFuncArr extends FunctionRet<JimpPlugin | JimpType>
 > = UnionToIntersection<GetPluginFuncArrValues<PluginFuncArr>>;
+
+type GetPluginFuncArrConsts<PluginFuncArr> =
+  // Given an array of types infer `Q` (Q should be the type value)
+  PluginFuncArr extends ReadonlyArray<() => infer Q>
+  ? // Get the plugin constants, may be ill-formed or well-formed
+    GetPluginConst<Q>
+  : // This should never be reached
+    undefined;
+
+type GetPluginFuncArrEncoders<PluginFuncArr> =
+  // Given an array of types infer `Q` (Q should be the type value)
+  PluginFuncArr extends ReadonlyArray<() => infer Q>
+  ? // Get the plugin encoders, may be ill-formed or well-formed
+    GetPluginEncoders<Q>
+  : // This should never be reached
+    undefined;
+
+type GetPluginFuncArrDecoders<PluginFuncArr> =
+  // Given an array of types infer `Q` (Q should be the type value)
+  PluginFuncArr extends ReadonlyArray<() => infer Q>
+  ? // Get the plugin decoders, may be ill-formed or well-formed
+    GetPluginDecoders<Q>
+  : // This should never be reached
+    undefined;
+
+/**
+ * A helper type to get the statics to be intersected with `Jimp` to give
+ * the proper typing given an array of functions for plugins and types
+ */
+export type GetIntersectionFromPluginsStatics<
+  PluginFuncArr extends FunctionRet<JimpPlugin | JimpType>
+> = UnionToIntersection<GetPluginFuncArrConsts<PluginFuncArr>> & {
+  encoders: UnionToIntersection<GetPluginFuncArrEncoders<PluginFuncArr>>;
+  decoders: UnionToIntersection<GetPluginFuncArrDecoders<PluginFuncArr>>;
+};
 
 /**
  * While this was added to TS 3.5, in order to support down to TS 2.8, we need

--- a/packages/core/types/utils.d.ts
+++ b/packages/core/types/utils.d.ts
@@ -32,11 +32,11 @@ export type FunctionRet<T> = Array<(...props: any[] | never) => T>;
  * up `undefined`. Because we're always extending `IllformedPlugin` on the
  * plugins, this should work fine
  */
-export type GetPluginVal<Q> = Q extends Required<{class: any}> | Required<{constant: any}>
+export type GetPluginVal<Q> = Q extends Required<{class: any}> | Required<{constants: any}>
   ? WellFormedValues<Q>
   : Q;
 
-export type GetPluginConst<Q> = Q extends Required<{class: any}> | Required<{constant: any}>
+export type GetPluginConst<Q> = Q extends Required<{class: any}> | Required<{constants: any}>
   ? WellFormedConstants<Q>
   : {};
 

--- a/packages/core/types/utils.d.ts
+++ b/packages/core/types/utils.d.ts
@@ -13,7 +13,13 @@ export type UnionToIntersection<U> =
  * Left loose as "any" in order to enable the GetPluginValue to work properly
  */
 export type WellFormedValues<T extends any> = 
-  (T extends {class: any} ? T['class'] : {}) &
+  (T extends {class: any} ? T['class'] : {});
+
+/**
+ * The constants to be extracted from a WellFormedPlugin to put onto the Jimp instance
+ * Left loose as "any" in order to enable the GetPluginConstants to work properly
+ */
+export type WellFormedConstants<T extends any> =
   (T extends {constants: any} ? T['constants'] : {});
 
 // Util type for the functions that deal with `@jimp/custom`
@@ -29,6 +35,10 @@ export type FunctionRet<T> = Array<(...props: any[] | never) => T>;
 export type GetPluginVal<Q> = Q extends Required<{class: any}> | Required<{constant: any}>
   ? WellFormedValues<Q>
   : Q;
+
+export type GetPluginConst<Q> = Q extends Required<{class: any}> | Required<{constant: any}>
+  ? WellFormedConstants<Q>
+  : {};
 
 type GetPluginFuncArrValues<PluginFuncArr> =
   // Given an array of types infer `Q` (Q should be the type value)

--- a/packages/custom/types/index.d.ts
+++ b/packages/custom/types/index.d.ts
@@ -6,21 +6,22 @@ import {
   JimpPlugin,
   JimpType,
   GetIntersectionFromPlugins,
+  GetIntersectionFromPluginsStatics,
   JimpConstructors
 } from '@jimp/core';
 
 type JimpInstance<
   TypesFuncArr extends FunctionRet<JimpType> | undefined,
   PluginFuncArr extends FunctionRet<JimpPlugin> | undefined,
-  J extends Jimp
-> = Exclude<J, undefined> &
-  GetIntersectionFromPlugins<Exclude<TypesFuncArr | PluginFuncArr, undefined>> &
-  JimpConstructors;
+  J extends JimpConstructors
+> = J & GetIntersectionFromPluginsStatics<Exclude<TypesFuncArr | PluginFuncArr, undefined>> & {
+  prototype: JimpType & GetIntersectionFromPlugins<Exclude<TypesFuncArr | PluginFuncArr, undefined>>
+};
 
 declare function configure<
   TypesFuncArr extends FunctionRet<JimpType> | undefined = undefined,
   PluginFuncArr extends FunctionRet<JimpPlugin> | undefined = undefined,
-  J extends Jimp = Jimp
+  J extends JimpConstructors = JimpConstructors
 >(
   configuration: {
     types?: TypesFuncArr;

--- a/packages/custom/types/test.ts
+++ b/packages/custom/types/test.ts
@@ -43,7 +43,6 @@ test('should function the same as the `jimp` types', () => {
   // Main Jimp export should already have all of these already applied
   FullCustomJimp.read('Test');
 
-  FullCustomJimp.resize(40, 40);
   // $ExpectType 0
   FullCustomJimp.PNG_FILTER_NONE;
 
@@ -149,7 +148,7 @@ test('can handle custom jimp', () => {
   Jiimp.PNG_FILTER_NONE;
 
   // Core functions should still work from Jimp
-  Jiimp.read('Test');
+  Jiimp.getPixelColor(1, 1);
 
   // Constants should be applied from ill-formed plugins
   Jiimp.displace(Jiimp, 2);
@@ -157,7 +156,8 @@ test('can handle custom jimp', () => {
   // Methods should be applied from well-formed plugins
   Jiimp.resize(40, 40)
 
-  // Constants should be applied from well-formed plugins
+  // Constants should not be applied to the object
+  // $ExpectError
   Jiimp.RESIZE_NEAREST_NEIGHBOR
 
   // $ExpectError
@@ -171,12 +171,6 @@ test('can compose', () => {
   const OtherCustomJimp = configure({
       plugins: [scale]
     }, CustomJimp);
-
-  // Methods from new plugins should be applied
-  OtherCustomJimp.scale(3);
-
-  // Methods from types should be applied
-  OtherCustomJimp.filterType(4);
   // Constants from types should be applied
   // $ExpectType 0
   OtherCustomJimp.PNG_FILTER_NONE;
@@ -184,10 +178,12 @@ test('can compose', () => {
   // Core functions should still work from Jimp
   OtherCustomJimp.read('Test');
 
-  // Constants should be applied from ill-formed plugins
+  // Constants should not be applied to the static instance from ill-formed plugins
+  // $ExpectError
   OtherCustomJimp.displace(OtherCustomJimp, 2);
 
-  // Methods should be applied from well-formed plugins
+  // Methods should not be applied to the static instance from well-formed plugins
+  // $ExpectError
   OtherCustomJimp.resize(40, 40);
 
   // Constants should be applied from well-formed plugins
@@ -202,12 +198,18 @@ test('can compose', () => {
   const Jiimp = new OtherCustomJimp('test');
   // Methods from types should be applied
   Jiimp.deflateLevel(4);
-  // Constants from types should be applied
-  // $ExpectType 0
+  // Constants from types should not be applied to objects
+  // $ExpectError
   Jiimp.PNG_FILTER_NONE;
 
+  // Methods from new plugins should be applied
+  Jiimp.scale(3);
+
+  // Methods from types should be applied
+  Jiimp.filterType(4);
+
   // Core functions should still work from Jimp
-  Jiimp.read('Test');
+  Jiimp.getPixelColor(1, 1);
 
   // Constants should be applied from ill-formed plugins
   Jiimp.displace(Jiimp, 2);
@@ -215,7 +217,8 @@ test('can compose', () => {
   // Methods should be applied from well-formed plugins
   Jiimp.resize(40, 40)
 
-  // Constants should be applied from well-formed plugins
+  // Constants should not be applied from well-formed plugins to objects
+  // $ExpectError
   Jiimp.RESIZE_NEAREST_NEIGHBOR
 
   // $ExpectError
@@ -355,6 +358,7 @@ test('can handle only one plugin', () => {
   // $ExpectType "nearestNeighbor"
   ResizeJimp.RESIZE_NEAREST_NEIGHBOR;
 
+  // $ExpectError
   ResizeJimp.resize(2, 2);
 
   // $ExpectError

--- a/packages/custom/types/test.ts
+++ b/packages/custom/types/test.ts
@@ -23,10 +23,15 @@ test('should function the same as the `jimp` types', () => {
   const jimpInst = new FullCustomJimp('test');
 
   // Main Jimp export should already have all of these already applied
+  // $ExpectError
   jimpInst.read('Test');
   jimpInst.displace(jimpInst, 2);
   jimpInst.resize(40, 40);
-  // $ExpectType 0
+  jimpInst.displace(jimpInst, 2);
+  jimpInst.shadow((err, val, coords) => {});
+  jimpInst.fishEye({r: 12});
+  jimpInst.circle({radius: 12, x: 12, y: 12});
+  // $ExpectError
   jimpInst.PNG_FILTER_NONE;
 
   // $ExpectError
@@ -37,7 +42,7 @@ test('should function the same as the `jimp` types', () => {
 
   // Main Jimp export should already have all of these already applied
   FullCustomJimp.read('Test');
-  FullCustomJimp.displace(FullCustomJimp, 2);
+
   FullCustomJimp.resize(40, 40);
   // $ExpectType 0
   FullCustomJimp.PNG_FILTER_NONE;
@@ -52,12 +57,12 @@ test('should function the same as the `jimp` types', () => {
     const baseImage = await FullCustomJimp.read('filename');
     const cloneBaseImage = baseImage.clone();
 
-    // $ExpectType -1
-    cloneBaseImage.PNG_FILTER_AUTO;
+    // $ExpectType number
+    cloneBaseImage._deflateLevel;
 
     test('can handle `this` returns on the core type properly', () => {
-      // $ExpectType -1
-      cloneBaseImage.diff(jimpInst, jimpInst).image.PNG_FILTER_AUTO
+      // $ExpectType number
+      cloneBaseImage.posterize(3)._quality
     });
 
     test('can handle `this` returns properly', () => {
@@ -69,16 +74,17 @@ test('should function the same as the `jimp` types', () => {
         .resize(1, 1)
         .quality(1)
         .deflateLevel(2)
-        .PNG_FILTER_AUTO;
+        ._filterType;
     });
 
     test('can handle imageCallbacks `this` properly', () => {
       cloneBaseImage.rgba(false, (_, jimpCBIn) => {
+        // $ExpectError
         jimpCBIn.read('Test');
         jimpCBIn.displace(jimpInst, 2);
         jimpCBIn.resize(40, 40);
-        // $ExpectType 0
-        jimpCBIn.PNG_FILTER_NONE;
+        // $ExpectType number
+        jimpCBIn._filterType;
 
         // $ExpectError
         jimpCBIn.test;
@@ -88,22 +94,42 @@ test('should function the same as the `jimp` types', () => {
       })
     })
   });
+
+  test('Can handle callback with constructor', () => {
+    const myBmpBuffer: Buffer = {} as any;
+
+    Jimp.read(myBmpBuffer, (err, cbJimpInst) => {
+      // $ExpectError
+      cbJimpInst.read('Test');
+      cbJimpInst.displace(jimpInst, 2);
+      cbJimpInst.resize(40, 40);
+      // $ExpectType number
+      cbJimpInst._filterType;
+
+      // $ExpectError
+      cbJimpInst.test;
+
+      // $ExpectError
+      cbJimpInst.func();
+    });
+  });
+
 });
 
 test('can handle custom jimp', () => {
-  // Methods from types should be applied
-  CustomJimp.deflateLevel(4);
   // Constants from types should be applied
   // $ExpectType 0
   CustomJimp.PNG_FILTER_NONE;
   
   // Core functions should still work from Jimp
   CustomJimp.read('Test');
-  
-  // Constants should be applied from ill-formed plugins
+
+  // Constants should not(?) be applied from ill-formed plugins
+  // $ExpectError
   CustomJimp.displace(CustomJimp, 2);
-  
-  // Methods should be applied from well-formed plugins
+
+  // Methods should be applied from well-formed plugins only to the instance
+  // $ExpectError
   CustomJimp.resize(40, 40)
   
   // Constants should be applied from well-formed plugins
@@ -118,8 +144,8 @@ test('can handle custom jimp', () => {
   const Jiimp = new CustomJimp('test');
   // Methods from types should be applied
   Jiimp.deflateLevel(4);
-  // Constants from types should be applied
-  // $ExpectType 0
+  // Constants from types should be applied to the static only
+  // $ExpectError
   Jiimp.PNG_FILTER_NONE;
 
   // Core functions should still work from Jimp
@@ -207,10 +233,12 @@ test('can handle only plugins', () => {
   // Core functions should still work from Jimp
   PluginsJimp.read('Test');
 
-  // Constants should be applied from ill-formed plugins
+  // Constants should not be applied from ill-formed plugins
+  // $ExpectError
   PluginsJimp.displace(PluginsJimp, 2);
 
-  // Methods should be applied from well-formed plugins
+  // Methods should be not be applied to from well-formed plugins to the top level
+  // $ExpectError
   PluginsJimp.resize(40, 40);
 
   // Constants should be applied from well-formed plugins
@@ -226,7 +254,7 @@ test('can handle only plugins', () => {
   const Jiimp = new PluginsJimp('test');
   
   // Core functions should still work from Jimp
-  Jiimp.read('Test');
+  Jiimp.getPixelColor(1, 1);
 
   // Constants should be applied from ill-formed plugins
   Jiimp.displace(Jiimp, 2);
@@ -234,7 +262,8 @@ test('can handle only plugins', () => {
   // Methods should be applied from well-formed plugins
   Jiimp.resize(40, 40)
 
-  // Constants should be applied from well-formed plugins
+  // Constants should be not applied to objects from well-formed plugins
+  // $ExpectError
   Jiimp.RESIZE_NEAREST_NEIGHBOR
 
   // $ExpectError
@@ -249,7 +278,8 @@ test('can handle only all types', () => {
     types: [types]
   });
 
-  // Methods from types should be applied
+  // Methods from types should not be applied
+  // $ExpectError
   TypesJimp.filterType(4);
   // Constants from types should be applied
   // $ExpectType 0
@@ -264,8 +294,8 @@ test('can handle only all types', () => {
   const Jiimp = new TypesJimp('test');
   // Methods from types should be applied
   Jiimp.filterType(4);
-  // Constants from types should be applied
-  // $ExpectType 0
+  // Constants from types should be not applied to objects
+  // $ExpectError
   Jiimp.PNG_FILTER_NONE;
 
   // $ExpectError
@@ -300,8 +330,8 @@ test('can handle only one type', () => {
   // $ExpectError
   Jiimp.MIME_TIFF;
 
-  // Constants from types should be applied
-  // $ExpectType 0
+  // Constants from types should not be applied to objects
+  // $ExpectError
   Jiimp.PNG_FILTER_NONE;
 
   // $ExpectError
@@ -334,13 +364,13 @@ test('can handle only one plugin', () => {
   ResizeJimp.func();
 
 
-  const Jiimp: typeof ResizeJimp = new ResizeJimp('test');
+  const Jiimp: InstanceType<typeof ResizeJimp> = new ResizeJimp('test');
   // Constants from other plugins should be not applied
   // $ExpectError
   Jiimp.FONT_SANS_8_BLACK;
 
-  // Constants from plugin should be applied
-  // $ExpectType "nearestNeighbor"
+  // Constants from plugin should not be applied to the object
+  // $ExpectError
   Jiimp.RESIZE_NEAREST_NEIGHBOR;
 
   Jiimp.resize(2, 2);

--- a/packages/jimp/types/ts3.1/index.d.ts
+++ b/packages/jimp/types/ts3.1/index.d.ts
@@ -13,6 +13,8 @@ import {
   UnionToIntersection,
   GetPluginVal,
   GetPluginConst,
+  GetPluginEncoders,
+  GetPluginDecoders,
   JimpConstructors
 } from '@jimp/core';
 import typeFn from '@jimp/types';
@@ -29,8 +31,20 @@ type IntersectedPluginConsts = UnionToIntersection<
   GetPluginConst<Types> | GetPluginConst<Plugins>
 >;
 
+type IntersectedPluginEncoders = UnionToIntersection<
+  GetPluginEncoders<Types> | GetPluginEncoders<Plugins>
+>;
+
+type IntersectedPluginDecoders = UnionToIntersection<
+  GetPluginDecoders<Types> | GetPluginDecoders<Plugins>
+>;
+
 type Jimp = JimpType & IntersectedPluginTypes;
 
-declare const Jimp: JimpConstructors & IntersectedPluginConsts & { prototype: Jimp };
+declare const Jimp: JimpConstructors & IntersectedPluginConsts & {
+  prototype: Jimp;
+  encoders: IntersectedPluginEncoders;
+  decoders: IntersectedPluginDecoders
+};
 
 export = Jimp;

--- a/packages/jimp/types/ts3.1/index.d.ts
+++ b/packages/jimp/types/ts3.1/index.d.ts
@@ -44,7 +44,7 @@ type Jimp = JimpType & IntersectedPluginTypes;
 declare const Jimp: JimpConstructors & IntersectedPluginConsts & {
   prototype: Jimp;
   encoders: IntersectedPluginEncoders;
-  decoders: IntersectedPluginDecoders
+  decoders: IntersectedPluginDecoders;
 };
 
 export = Jimp;

--- a/packages/jimp/types/ts3.1/index.d.ts
+++ b/packages/jimp/types/ts3.1/index.d.ts
@@ -12,6 +12,7 @@ import {
   RGBA,
   UnionToIntersection,
   GetPluginVal,
+  GetPluginConst,
   JimpConstructors
 } from '@jimp/core';
 import typeFn from '@jimp/types';
@@ -24,8 +25,12 @@ type IntersectedPluginTypes = UnionToIntersection<
   GetPluginVal<Types> | GetPluginVal<Plugins>
 >;
 
-type Jimp = InstanceType<JimpType> & IntersectedPluginTypes;
+type IntersectedPluginConsts = UnionToIntersection<
+  GetPluginConst<Types> | GetPluginConst<Plugins>
+>;
 
-declare const Jimp: JimpConstructors & Jimp;
+type Jimp = JimpType & IntersectedPluginTypes;
+
+declare const Jimp: JimpConstructors & IntersectedPluginConsts & { prototype: Jimp };
 
 export = Jimp;

--- a/packages/jimp/types/ts3.1/test.ts
+++ b/packages/jimp/types/ts3.1/test.ts
@@ -23,7 +23,6 @@ jimpInst.func();
 // Main Jimp export should already have all of these already applied
 Jimp.read('Test');
 
-Jimp.resize(40, 40);
 // $ExpectType 0
 Jimp.PNG_FILTER_NONE;
 
@@ -84,7 +83,7 @@ test('Can handle callback with constructor', () => {
     cbJimpInst.displace(jimpInst, 2);
     cbJimpInst.resize(40, 40);
     // $ExpectType number
-    jimpCBIn._filterType;
+    cbJimpInst._filterType;
 
     // $ExpectError
     cbJimpInst.test;

--- a/packages/jimp/types/ts3.1/test.ts
+++ b/packages/jimp/types/ts3.1/test.ts
@@ -3,10 +3,15 @@ import * as Jimp from 'jimp';
 const jimpInst: Jimp = new Jimp('test');
 
 // Main Jimp export should already have all of these already applied
+// $ExpectError
 jimpInst.read('Test');
 jimpInst.displace(jimpInst, 2);
 jimpInst.resize(40, 40);
-// $ExpectType 0
+jimpInst.displace(jimpInst, 2);
+jimpInst.shadow((err, val, coords) => {});
+jimpInst.fishEye({r: 12});
+jimpInst.circle({radius: 12, x: 12, y: 12});
+// $ExpectError
 jimpInst.PNG_FILTER_NONE;
 
 // $ExpectError
@@ -17,10 +22,6 @@ jimpInst.func();
 
 // Main Jimp export should already have all of these already applied
 Jimp.read('Test');
-Jimp.displace(Jimp, 2);
-Jimp.shadow((err, val, coords) => {});
-Jimp.fishEye({r: 12});
-Jimp.circle({radius: 12, x: 12, y: 12});
 
 Jimp.resize(40, 40);
 // $ExpectType 0
@@ -36,12 +37,12 @@ test('can clone properly', async () => {
   const baseImage = await Jimp.read('filename');
   const cloneBaseImage = baseImage.clone();
 
-  // $ExpectType -1
-  cloneBaseImage.PNG_FILTER_AUTO;
+  // $ExpectType number
+  cloneBaseImage._deflateLevel;
 
   test('can handle `this` returns on the core type properly', () => {
-    // $ExpectType -1
-    cloneBaseImage.diff(jimpInst, jimpInst).image.PNG_FILTER_AUTO
+    // $ExpectType number
+    cloneBaseImage.posterize(3)._quality
   });
   
   test('can handle `this` returns properly', () => {
@@ -53,16 +54,17 @@ test('can clone properly', async () => {
       .resize(1, 1)
       .quality(1)
       .deflateLevel(2)
-      .PNG_FILTER_AUTO;
+      ._filterType;
   });
   
   test('can handle imageCallbacks `this` properly', () => {
     cloneBaseImage.rgba(false, (_, jimpCBIn) => {
+      // $ExpectError
       jimpCBIn.read('Test');
       jimpCBIn.displace(jimpInst, 2);
       jimpCBIn.resize(40, 40);
-      // $ExpectType 0
-      jimpCBIn.PNG_FILTER_NONE;
+      // $ExpectType number
+      jimpCBIn._filterType;
 
       // $ExpectError
       jimpCBIn.test;
@@ -77,11 +79,12 @@ test('Can handle callback with constructor', () => {
   const myBmpBuffer: Buffer = {} as any;
 
   Jimp.read(myBmpBuffer, (err, cbJimpInst) => {
+    // $ExpectError
     cbJimpInst.read('Test');
     cbJimpInst.displace(jimpInst, 2);
     cbJimpInst.resize(40, 40);
-    // $ExpectType 0
-    cbJimpInst.PNG_FILTER_NONE;
+    // $ExpectType number
+    jimpCBIn._filterType;
 
     // $ExpectError
     cbJimpInst.test;

--- a/packages/type-jpeg/index.d.ts
+++ b/packages/type-jpeg/index.d.ts
@@ -1,7 +1,6 @@
 import { DecoderFn, EncoderFn, ImageCallback } from '@jimp/core';
 
 interface JpegClass {
-  MIME_JPEG: 'image/jpeg';
   _quality: number;
   quality: (n: number, cb?: ImageCallback<this>) => this;
 }
@@ -10,7 +9,7 @@ interface Jpeg {
   mime: { 'image/jpeg': string[] },
 
   constants: {
-    'image/jpeg': string
+    MIME_JPEG: 'image/jpeg';
   }
 
   encoders: {


### PR DESCRIPTION
Fixes #803

# What's Changing and Why

Currently, the typings indicate that one can do the following:

```ts
import Jimp = require('jimp');
const jimpInst: Jimp = new Jimp(0, 0);
// Typings indicate that this is 'image/jpeg'
jimpInst.MIME_JPEG
```

But actually running it (in a repl) shows

```js
> var Jimp = require('jimp');
undefined
> var jimpInst = new Jimp(0, 0);
undefined
> jimpInst.MIME_JPEG
undefined
```

This change fixes that, and splits the instance type from the class constructor type.

## What else might be affected

The jpeg plugin's constants typing was incorrect, idk about other plugins (that one was caught as it was used in my code)

## Tasks

- [x] Add tests
- [ ] ~Update Documentation~
- [x] Update `jimp.d.ts`
- [ ] Add [SemVer](https://semver.org/) Label

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.9.9-canary.867.792.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @jimp/cli@0.9.9-canary.867.792.0
  npm install @jimp/core@0.9.9-canary.867.792.0
  npm install @jimp/custom@0.9.9-canary.867.792.0
  npm install jimp@0.9.9-canary.867.792.0
  npm install @jimp/plugin-blit@0.9.9-canary.867.792.0
  npm install @jimp/plugin-blur@0.9.9-canary.867.792.0
  npm install @jimp/plugin-circle@0.9.9-canary.867.792.0
  npm install @jimp/plugin-color@0.9.9-canary.867.792.0
  npm install @jimp/plugin-contain@0.9.9-canary.867.792.0
  npm install @jimp/plugin-cover@0.9.9-canary.867.792.0
  npm install @jimp/plugin-crop@0.9.9-canary.867.792.0
  npm install @jimp/plugin-displace@0.9.9-canary.867.792.0
  npm install @jimp/plugin-dither@0.9.9-canary.867.792.0
  npm install @jimp/plugin-fisheye@0.9.9-canary.867.792.0
  npm install @jimp/plugin-flip@0.9.9-canary.867.792.0
  npm install @jimp/plugin-gaussian@0.9.9-canary.867.792.0
  npm install @jimp/plugin-invert@0.9.9-canary.867.792.0
  npm install @jimp/plugin-mask@0.9.9-canary.867.792.0
  npm install @jimp/plugin-normalize@0.9.9-canary.867.792.0
  npm install @jimp/plugin-print@0.9.9-canary.867.792.0
  npm install @jimp/plugin-resize@0.9.9-canary.867.792.0
  npm install @jimp/plugin-rotate@0.9.9-canary.867.792.0
  npm install @jimp/plugin-scale@0.9.9-canary.867.792.0
  npm install @jimp/plugin-shadow@0.9.9-canary.867.792.0
  npm install @jimp/plugin-threshold@0.9.9-canary.867.792.0
  npm install @jimp/plugins@0.9.9-canary.867.792.0
  npm install @jimp/test-utils@0.9.9-canary.867.792.0
  npm install @jimp/bmp@0.9.9-canary.867.792.0
  npm install @jimp/gif@0.9.9-canary.867.792.0
  npm install @jimp/jpeg@0.9.9-canary.867.792.0
  npm install @jimp/png@0.9.9-canary.867.792.0
  npm install @jimp/tiff@0.9.9-canary.867.792.0
  npm install @jimp/types@0.9.9-canary.867.792.0
  npm install @jimp/utils@0.9.9-canary.867.792.0
  # or 
  yarn add @jimp/cli@0.9.9-canary.867.792.0
  yarn add @jimp/core@0.9.9-canary.867.792.0
  yarn add @jimp/custom@0.9.9-canary.867.792.0
  yarn add jimp@0.9.9-canary.867.792.0
  yarn add @jimp/plugin-blit@0.9.9-canary.867.792.0
  yarn add @jimp/plugin-blur@0.9.9-canary.867.792.0
  yarn add @jimp/plugin-circle@0.9.9-canary.867.792.0
  yarn add @jimp/plugin-color@0.9.9-canary.867.792.0
  yarn add @jimp/plugin-contain@0.9.9-canary.867.792.0
  yarn add @jimp/plugin-cover@0.9.9-canary.867.792.0
  yarn add @jimp/plugin-crop@0.9.9-canary.867.792.0
  yarn add @jimp/plugin-displace@0.9.9-canary.867.792.0
  yarn add @jimp/plugin-dither@0.9.9-canary.867.792.0
  yarn add @jimp/plugin-fisheye@0.9.9-canary.867.792.0
  yarn add @jimp/plugin-flip@0.9.9-canary.867.792.0
  yarn add @jimp/plugin-gaussian@0.9.9-canary.867.792.0
  yarn add @jimp/plugin-invert@0.9.9-canary.867.792.0
  yarn add @jimp/plugin-mask@0.9.9-canary.867.792.0
  yarn add @jimp/plugin-normalize@0.9.9-canary.867.792.0
  yarn add @jimp/plugin-print@0.9.9-canary.867.792.0
  yarn add @jimp/plugin-resize@0.9.9-canary.867.792.0
  yarn add @jimp/plugin-rotate@0.9.9-canary.867.792.0
  yarn add @jimp/plugin-scale@0.9.9-canary.867.792.0
  yarn add @jimp/plugin-shadow@0.9.9-canary.867.792.0
  yarn add @jimp/plugin-threshold@0.9.9-canary.867.792.0
  yarn add @jimp/plugins@0.9.9-canary.867.792.0
  yarn add @jimp/test-utils@0.9.9-canary.867.792.0
  yarn add @jimp/bmp@0.9.9-canary.867.792.0
  yarn add @jimp/gif@0.9.9-canary.867.792.0
  yarn add @jimp/jpeg@0.9.9-canary.867.792.0
  yarn add @jimp/png@0.9.9-canary.867.792.0
  yarn add @jimp/tiff@0.9.9-canary.867.792.0
  yarn add @jimp/types@0.9.9-canary.867.792.0
  yarn add @jimp/utils@0.9.9-canary.867.792.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
