### PR TITLE
Fix a `loadFont` and case inconsistency of `jimp`

### DIFF
--- a/packages/plugin-print/README.md
+++ b/packages/plugin-print/README.md
@@ -41,10 +41,10 @@ Loads a bitmap font from a file
 - @returns {Promise} a promise
 
 ```js
-import jimp from 'jimp';
+import Jimp from 'jimp';
 
 async function main() {
-  const font = await jimp.read(jimp.FONT_SANS_32_BLACK);
+  const font = await Jimp.loadFont(Jimp.FONT_SANS_32_BLACK);
 }
 
 main();
@@ -143,13 +143,13 @@ image.print(
 Measure how wide a piece of text will be.
 
 ```js
-import jimp from 'jimp';
+import Jimp from 'jimp';
 
 async function main() {
-  const font = await jimp.read(jimp.FONT_SANS_32_BLACK);
-  const image = await jimp.read(1000, 1000, 0x0000ffff);
+  const font = await Jimp.loadFont(Jimp.FONT_SANS_32_BLACK);
+  const image = await Jimp.read(1000, 1000, 0x0000ffff);
 
-  jimp.measureText(font, 'Hello World!');
+  Jimp.measureText(font, 'Hello World!');
 }
 
 main();
@@ -160,13 +160,13 @@ main();
 Measure how tall a piece of text will be.
 
 ```js
-import jimp from 'jimp';
+import Jimp from 'jimp';
 
 async function main() {
-  const font = await jimp.read(jimp.FONT_SANS_32_BLACK);
-  const image = await jimp.read(1000, 1000, 0x0000ffff);
+  const font = await Jimp.loadFont(Jimp.FONT_SANS_32_BLACK);
+  const image = await Jimp.read(1000, 1000, 0x0000ffff);
 
-  jimp.measureTextHeight(font, 'Hello World!', 100);
+  Jimp.measureTextHeight(font, 'Hello World!', 100);
 }
 
 main();


### PR DESCRIPTION
Fix the documentation
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.9.9-canary.868.799.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @jimp/cli@0.9.9-canary.868.799.0
  npm install @jimp/core@0.9.9-canary.868.799.0
  npm install @jimp/custom@0.9.9-canary.868.799.0
  npm install jimp@0.9.9-canary.868.799.0
  npm install @jimp/plugin-blit@0.9.9-canary.868.799.0
  npm install @jimp/plugin-blur@0.9.9-canary.868.799.0
  npm install @jimp/plugin-circle@0.9.9-canary.868.799.0
  npm install @jimp/plugin-color@0.9.9-canary.868.799.0
  npm install @jimp/plugin-contain@0.9.9-canary.868.799.0
  npm install @jimp/plugin-cover@0.9.9-canary.868.799.0
  npm install @jimp/plugin-crop@0.9.9-canary.868.799.0
  npm install @jimp/plugin-displace@0.9.9-canary.868.799.0
  npm install @jimp/plugin-dither@0.9.9-canary.868.799.0
  npm install @jimp/plugin-fisheye@0.9.9-canary.868.799.0
  npm install @jimp/plugin-flip@0.9.9-canary.868.799.0
  npm install @jimp/plugin-gaussian@0.9.9-canary.868.799.0
  npm install @jimp/plugin-invert@0.9.9-canary.868.799.0
  npm install @jimp/plugin-mask@0.9.9-canary.868.799.0
  npm install @jimp/plugin-normalize@0.9.9-canary.868.799.0
  npm install @jimp/plugin-print@0.9.9-canary.868.799.0
  npm install @jimp/plugin-resize@0.9.9-canary.868.799.0
  npm install @jimp/plugin-rotate@0.9.9-canary.868.799.0
  npm install @jimp/plugin-scale@0.9.9-canary.868.799.0
  npm install @jimp/plugin-shadow@0.9.9-canary.868.799.0
  npm install @jimp/plugin-threshold@0.9.9-canary.868.799.0
  npm install @jimp/plugins@0.9.9-canary.868.799.0
  npm install @jimp/test-utils@0.9.9-canary.868.799.0
  npm install @jimp/bmp@0.9.9-canary.868.799.0
  npm install @jimp/gif@0.9.9-canary.868.799.0
  npm install @jimp/jpeg@0.9.9-canary.868.799.0
  npm install @jimp/png@0.9.9-canary.868.799.0
  npm install @jimp/tiff@0.9.9-canary.868.799.0
  npm install @jimp/types@0.9.9-canary.868.799.0
  npm install @jimp/utils@0.9.9-canary.868.799.0
  # or 
  yarn add @jimp/cli@0.9.9-canary.868.799.0
  yarn add @jimp/core@0.9.9-canary.868.799.0
  yarn add @jimp/custom@0.9.9-canary.868.799.0
  yarn add jimp@0.9.9-canary.868.799.0
  yarn add @jimp/plugin-blit@0.9.9-canary.868.799.0
  yarn add @jimp/plugin-blur@0.9.9-canary.868.799.0
  yarn add @jimp/plugin-circle@0.9.9-canary.868.799.0
  yarn add @jimp/plugin-color@0.9.9-canary.868.799.0
  yarn add @jimp/plugin-contain@0.9.9-canary.868.799.0
  yarn add @jimp/plugin-cover@0.9.9-canary.868.799.0
  yarn add @jimp/plugin-crop@0.9.9-canary.868.799.0
  yarn add @jimp/plugin-displace@0.9.9-canary.868.799.0
  yarn add @jimp/plugin-dither@0.9.9-canary.868.799.0
  yarn add @jimp/plugin-fisheye@0.9.9-canary.868.799.0
  yarn add @jimp/plugin-flip@0.9.9-canary.868.799.0
  yarn add @jimp/plugin-gaussian@0.9.9-canary.868.799.0
  yarn add @jimp/plugin-invert@0.9.9-canary.868.799.0
  yarn add @jimp/plugin-mask@0.9.9-canary.868.799.0
  yarn add @jimp/plugin-normalize@0.9.9-canary.868.799.0
  yarn add @jimp/plugin-print@0.9.9-canary.868.799.0
  yarn add @jimp/plugin-resize@0.9.9-canary.868.799.0
  yarn add @jimp/plugin-rotate@0.9.9-canary.868.799.0
  yarn add @jimp/plugin-scale@0.9.9-canary.868.799.0
  yarn add @jimp/plugin-shadow@0.9.9-canary.868.799.0
  yarn add @jimp/plugin-threshold@0.9.9-canary.868.799.0
  yarn add @jimp/plugins@0.9.9-canary.868.799.0
  yarn add @jimp/test-utils@0.9.9-canary.868.799.0
  yarn add @jimp/bmp@0.9.9-canary.868.799.0
  yarn add @jimp/gif@0.9.9-canary.868.799.0
  yarn add @jimp/jpeg@0.9.9-canary.868.799.0
  yarn add @jimp/png@0.9.9-canary.868.799.0
  yarn add @jimp/tiff@0.9.9-canary.868.799.0
  yarn add @jimp/types@0.9.9-canary.868.799.0
  yarn add @jimp/utils@0.9.9-canary.868.799.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
