### PR TITLE
Rewrite handling EXIF orientation — add tests, make it plugin-independent

### DIFF
--- a/packages/core/src/utils/image-bitmap.js
+++ b/packages/core/src/utils/image-bitmap.js
@@ -25,44 +25,127 @@ function getMIMEFromBuffer(buffer, path) {
 }
 
 /*
+ * Obtains image orientation from EXIF metadata.
+ *
+ * @param img {Jimp} a Jimp image object
+ * @returns {number} a number 1-8 representing EXIF orientation,
+ *          in particular 1 if orientation tag is missing
+ */
+function getExifOrientation(img) {
+  return (img._exif && img._exif.tags && img._exif.tags.Orientation) || 1;
+}
+
+/**
+ * Returns a function which translates EXIF-rotated coordinates into
+ * non-rotated ones.
+ *
+ * Transformation reference: http://sylvana.net/jpegcrop/exif_orientation.html.
+ *
+ * @param img {Jimp} a Jimp image object
+ * @returns {function} transformation function for transformBitmap().
+ */
+function getExifOrientationTransformation(img) {
+  const w = img.getWidth();
+  const h = img.getHeight();
+
+  switch (getExifOrientation(img)) {
+    case 1: // Horizontal (normal)
+      // does not need to be supported here
+      return null;
+
+    case 2: // Mirror horizontal
+      return function(x, y) {
+        return [w - x - 1, y];
+      };
+
+    case 3: // Rotate 180
+      return function(x, y) {
+        return [w - x - 1, h - y - 1];
+      };
+
+    case 4: // Mirror vertical
+      return function(x, y) {
+        return [x, h - y - 1];
+      };
+
+    case 5: // Mirror horizontal and rotate 270 CW
+      return function(x, y) {
+        return [y, x];
+      };
+
+    case 6: // Rotate 90 CW
+      return function(x, y) {
+        return [y, h - x - 1];
+      };
+
+    case 7: // Mirror horizontal and rotate 90 CW
+      return function(x, y) {
+        return [w - y - 1, h - x - 1];
+      };
+
+    case 8: // Rotate 270 CW
+      return function(x, y) {
+        return [w - y - 1, x];
+      };
+
+    default:
+      return null;
+  }
+}
+
+/*
+ * Transforms bitmap in place (moves pixels around) according to given
+ * transformation function.
+ *
+ * @param img {Jimp} a Jimp image object, which bitmap is supposed to
+ *        be transformed
+ * @param width {number} bitmap width after the transformation
+ * @param height {number} bitmap height after the transformation
+ * @param transformation {function} transformation function which defines pixel
+ *        mapping between new and source bitmap. It takes a pair of coordinates
+ *        in the target, and returns a respective pair of coordinates in
+ *        the source bitmap, i.e. has following form:
+ *        `function(new_x, new_y) { return [src_x, src_y] }`.
+ */
+function transformBitmap(img, width, height, transformation) {
+  // Underscore-prefixed values are related to the source bitmap
+  // Their counterparts with no prefix are related to the target bitmap
+  const _data = img.bitmap.data;
+  const _width = img.bitmap.width;
+
+  const data = Buffer.alloc(_data.length);
+
+  for (let x = 0; x < width; x++) {
+    for (let y = 0; y < height; y++) {
+      const [_x, _y] = transformation(x, y);
+
+      const idx = (width * y + x) << 2;
+      const _idx = (_width * _y + _x) << 2;
+
+      const pixel = _data.readUInt32BE(_idx);
+      data.writeUInt32BE(pixel, idx);
+    }
+  }
+
+  img.bitmap.data = data;
+  img.bitmap.width = width;
+  img.bitmap.height = height;
+}
+
+/*
  * Automagically rotates an image based on its EXIF data (if present).
  * @param img {Jimp} a Jimp image object
  */
 function exifRotate(img) {
-  const exif = img._exif;
+  if (getExifOrientation(img) < 2) return;
 
-  if (exif && exif.tags && exif.tags.Orientation) {
-    switch (img._exif.tags.Orientation) {
-      case 1: // Horizontal (normal)
-        // do nothing
-        break;
-      case 2: // Mirror horizontal
-        img.mirror(true, false);
-        break;
-      case 3: // Rotate 180
-        img.rotate(180);
-        break;
-      case 4: // Mirror vertical
-        img.mirror(false, true);
-        break;
-      case 5: // Mirror horizontal and rotate 270 CW
-        img.rotate(-90).mirror(true, false);
-        break;
-      case 6: // Rotate 90 CW
-        img.rotate(-90);
-        break;
-      case 7: // Mirror horizontal and rotate 90 CW
-        img.rotate(90).mirror(true, false);
-        break;
-      case 8: // Rotate 270 CW
-        img.rotate(-270);
-        break;
-      default:
-        break;
-    }
-  }
+  const transformation = getExifOrientationTransformation(img);
+  const swapDimensions = getExifOrientation(img) > 4;
 
-  return img;
+  const newWidth = swapDimensions ? img.bitmap.height : img.bitmap.width;
+  const newHeight = swapDimensions ? img.bitmap.width : img.bitmap.height;
+
+  transformBitmap(img, newWidth, newHeight, transformation);
 }
 
 // parses a bitmap from the constructor to the JIMP bitmap property

--- a/packages/core/src/utils/image-bitmap.js
+++ b/packages/core/src/utils/image-bitmap.js
@@ -25,8 +25,8 @@ function getMIMEFromBuffer(buffer, path) {
 }
 
 /*
- * Automagically rotates an image based on its EXIF data (if present)
- * @param img a constants object
+ * Automagically rotates an image based on its EXIF data (if present).
+ * @param img {Jimp} a Jimp image object
  */
 function exifRotate(img) {
   const exif = img._exif;

--- a/packages/jimp/test/exif-rotation.test.js
+++ b/packages/jimp/test/exif-rotation.test.js
@@ -1,9 +1,8 @@
 import { Jimp, getTestDir } from '@jimp/test-utils';
 
 import configure from '@jimp/custom';
-import plugins from '@jimp/plugins';
 
-const jimp = configure({ plugins: [plugins] }, Jimp);
+const jimp = configure({ plugins: [] }, Jimp);
 
 describe('EXIF orientation', () => {
   for (let orientation = 1; orientation <= 8; orientation++) {

--- a/packages/jimp/test/exif-rotation.test.js
+++ b/packages/jimp/test/exif-rotation.test.js
@@ -1,0 +1,25 @@
+import { Jimp, getTestDir } from '@jimp/test-utils';
+
+import configure from '@jimp/custom';
+import plugins from '@jimp/plugins';
+
+const jimp = configure({ plugins: [plugins] }, Jimp);
+
+describe('EXIF orientation', () => {
+  for (let orientation = 1; orientation <= 8; orientation++) {
+    it(`is fixed when EXIF orientation is ${orientation}`, async () => {
+      const regularImg = await imageWithOrientation(1);
+      const orientedImg = await imageWithOrientation(orientation);
+
+      orientedImg.getWidth().should.be.equal(regularImg.getWidth());
+      orientedImg.getHeight().should.be.equal(regularImg.getHeight());
+      Jimp.distance(regularImg, orientedImg).should.lessThan(0.07);
+    });
+  }
+});
+
+function imageWithOrientation(orientation) {
+  const imageName = `Landscape_${orientation}.jpg`;
+  const path = getTestDir(__dirname) + '/images/exif-orientation/' + imageName;
+  return jimp.read(path);
+}


### PR DESCRIPTION
# What's Changing and Why

Handling EXIF orientation has been rewritten from scratch. In a result:

- it no longer relies on plugins (flip, rotate, and others);
- solves issues coming from plugins like black border (#721) in scope of EXIF rotation;
- everything is performed in a single pass.

Pictures are now processed with bitmap transformation functions, which map pixels from source bitmap to correctly rotated one. Computational complexity is proportional to number of pixels in given picture.

Finally, tests for EXIF rotation are added in this pull request. They were missing so far.

## What else might be affected

It somewhat addresses #873, but list of dependencies of rotate plugin is still unclear.

I suppose nothing breaks. Public API is unaffected.

## Things to consider

Perhaps `transformBitmap()` should be promoted to public low-level API. Perhaps some plugins like flip can leverage it. For example, a whole flip vertically operation could be written as:

```js
transformBitmap(
  img,
  img.getWidth(),
  img.getHeight(),
  (x,y) => [img.getWidth() - x - 1, y],
);
```

## Tasks

- [x] Add tests
- [x] Update Documentation — not applicable IMO
- [ ] Update `jimp.d.ts` — I am not sure if it's needed here, no exported method has been changed
- [ ] Add [SemVer](https://semver.org/) Label — I don't know what should be done here, please advise
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.10.2-canary.875.842.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @jimp/cli@0.10.2-canary.875.842.0
  npm install @jimp/core@0.10.2-canary.875.842.0
  npm install @jimp/custom@0.10.2-canary.875.842.0
  npm install jimp@0.10.2-canary.875.842.0
  npm install @jimp/plugin-blit@0.10.2-canary.875.842.0
  npm install @jimp/plugin-blur@0.10.2-canary.875.842.0
  npm install @jimp/plugin-circle@0.10.2-canary.875.842.0
  npm install @jimp/plugin-color@0.10.2-canary.875.842.0
  npm install @jimp/plugin-contain@0.10.2-canary.875.842.0
  npm install @jimp/plugin-cover@0.10.2-canary.875.842.0
  npm install @jimp/plugin-crop@0.10.2-canary.875.842.0
  npm install @jimp/plugin-displace@0.10.2-canary.875.842.0
  npm install @jimp/plugin-dither@0.10.2-canary.875.842.0
  npm install @jimp/plugin-fisheye@0.10.2-canary.875.842.0
  npm install @jimp/plugin-flip@0.10.2-canary.875.842.0
  npm install @jimp/plugin-gaussian@0.10.2-canary.875.842.0
  npm install @jimp/plugin-invert@0.10.2-canary.875.842.0
  npm install @jimp/plugin-mask@0.10.2-canary.875.842.0
  npm install @jimp/plugin-normalize@0.10.2-canary.875.842.0
  npm install @jimp/plugin-print@0.10.2-canary.875.842.0
  npm install @jimp/plugin-resize@0.10.2-canary.875.842.0
  npm install @jimp/plugin-rotate@0.10.2-canary.875.842.0
  npm install @jimp/plugin-scale@0.10.2-canary.875.842.0
  npm install @jimp/plugin-shadow@0.10.2-canary.875.842.0
  npm install @jimp/plugin-threshold@0.10.2-canary.875.842.0
  npm install @jimp/plugins@0.10.2-canary.875.842.0
  npm install @jimp/test-utils@0.10.2-canary.875.842.0
  npm install @jimp/bmp@0.10.2-canary.875.842.0
  npm install @jimp/gif@0.10.2-canary.875.842.0
  npm install @jimp/jpeg@0.10.2-canary.875.842.0
  npm install @jimp/png@0.10.2-canary.875.842.0
  npm install @jimp/tiff@0.10.2-canary.875.842.0
  npm install @jimp/types@0.10.2-canary.875.842.0
  npm install @jimp/utils@0.10.2-canary.875.842.0
  # or 
  yarn add @jimp/cli@0.10.2-canary.875.842.0
  yarn add @jimp/core@0.10.2-canary.875.842.0
  yarn add @jimp/custom@0.10.2-canary.875.842.0
  yarn add jimp@0.10.2-canary.875.842.0
  yarn add @jimp/plugin-blit@0.10.2-canary.875.842.0
  yarn add @jimp/plugin-blur@0.10.2-canary.875.842.0
  yarn add @jimp/plugin-circle@0.10.2-canary.875.842.0
  yarn add @jimp/plugin-color@0.10.2-canary.875.842.0
  yarn add @jimp/plugin-contain@0.10.2-canary.875.842.0
  yarn add @jimp/plugin-cover@0.10.2-canary.875.842.0
  yarn add @jimp/plugin-crop@0.10.2-canary.875.842.0
  yarn add @jimp/plugin-displace@0.10.2-canary.875.842.0
  yarn add @jimp/plugin-dither@0.10.2-canary.875.842.0
  yarn add @jimp/plugin-fisheye@0.10.2-canary.875.842.0
  yarn add @jimp/plugin-flip@0.10.2-canary.875.842.0
  yarn add @jimp/plugin-gaussian@0.10.2-canary.875.842.0
  yarn add @jimp/plugin-invert@0.10.2-canary.875.842.0
  yarn add @jimp/plugin-mask@0.10.2-canary.875.842.0
  yarn add @jimp/plugin-normalize@0.10.2-canary.875.842.0
  yarn add @jimp/plugin-print@0.10.2-canary.875.842.0
  yarn add @jimp/plugin-resize@0.10.2-canary.875.842.0
  yarn add @jimp/plugin-rotate@0.10.2-canary.875.842.0
  yarn add @jimp/plugin-scale@0.10.2-canary.875.842.0
  yarn add @jimp/plugin-shadow@0.10.2-canary.875.842.0
  yarn add @jimp/plugin-threshold@0.10.2-canary.875.842.0
  yarn add @jimp/plugins@0.10.2-canary.875.842.0
  yarn add @jimp/test-utils@0.10.2-canary.875.842.0
  yarn add @jimp/bmp@0.10.2-canary.875.842.0
  yarn add @jimp/gif@0.10.2-canary.875.842.0
  yarn add @jimp/jpeg@0.10.2-canary.875.842.0
  yarn add @jimp/png@0.10.2-canary.875.842.0
  yarn add @jimp/tiff@0.10.2-canary.875.842.0
  yarn add @jimp/types@0.10.2-canary.875.842.0
  yarn add @jimp/utils@0.10.2-canary.875.842.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
