### PR TITLE
Simplify and fix flip

### DIFF
--- a/packages/plugin-flip/src/index.js
+++ b/packages/plugin-flip/src/index.js
@@ -15,11 +15,6 @@ function flipFn(horizontal, vertical, cb) {
       cb
     );
 
-  if (horizontal && vertical) {
-    // shortcut
-    return this.rotate(180, true, cb);
-  }
-
   const bitmap = Buffer.alloc(this.bitmap.data.length);
   this.scanQuiet(0, 0, this.bitmap.width, this.bitmap.height, function(
     x,

--- a/packages/plugin-flip/test/flipping.test.js
+++ b/packages/plugin-flip/test/flipping.test.js
@@ -1,0 +1,99 @@
+import { Jimp, mkJGD } from '@jimp/test-utils';
+
+import configure from '@jimp/custom';
+
+import flip from '../src';
+
+const jimp = configure({ plugins: [flip] }, Jimp);
+
+describe('Flipping plugin', () => {
+  it('can flip horizontally', async () => {
+    const src = await jimp.read(
+      mkJGD(
+        'AAAABBBB',
+        'AAABAAAB',
+        'ABABABAB',
+        'CCCCCCCC',
+        'CCCCCCCC',
+        'CCCCCCCC',
+        'AACCCCAA'
+      )
+    );
+
+    const result = src.flip(true, false);
+
+    result
+      .getJGDSync()
+      .should.be.sameJGD(
+        mkJGD(
+          'BBBBAAAA',
+          'BAAABAAA',
+          'BABABABA',
+          'CCCCCCCC',
+          'CCCCCCCC',
+          'CCCCCCCC',
+          'AACCCCAA'
+        )
+      );
+  });
+
+  it('can flip vertically', async () => {
+    const src = await jimp.read(
+      mkJGD(
+        'AAAABBBB',
+        'AAABAAAB',
+        'ABABABAB',
+        'CCCCCCCC',
+        'CCCCCCCC',
+        'CCCCCCCC',
+        'AACCCCAA'
+      )
+    );
+
+    const result = src.flip(false, true);
+
+    result
+      .getJGDSync()
+      .should.be.sameJGD(
+        mkJGD(
+          'AACCCCAA',
+          'CCCCCCCC',
+          'CCCCCCCC',
+          'CCCCCCCC',
+          'ABABABAB',
+          'AAABAAAB',
+          'AAAABBBB'
+        )
+      );
+  });
+
+  it('can flip both horizontally and vertically at once', async () => {
+    const src = await jimp.read(
+      mkJGD(
+        'AAAABBBB',
+        'AAABAAAB',
+        'ABABABAB',
+        'CCCCCCCC',
+        'CCCCCCCC',
+        'CCCCCCCC',
+        'AACCCCAA'
+      )
+    );
+
+    const result = src.flip(true, true);
+
+    result
+      .getJGDSync()
+      .should.be.sameJGD(
+        mkJGD(
+          'AACCCCAA',
+          'CCCCCCCC',
+          'CCCCCCCC',
+          'CCCCCCCC',
+          'BABABABA',
+          'BAAABAAA',
+          'BBBBAAAA'
+        )
+      );
+  });
+});


### PR DESCRIPTION
# What's Changing and Why

- Tests for Flip plugin are added.
- A code branch in Flip plugin is removed, as it was broken and unnecessary.

In the result of the latter:

- Computational complexity is the same or better.
- Flip plugin no longer depends on Rotate plugin.
- Implementation is simpler, shorter and has less bugs.

## What else might be affected

Fixes #829. API is unaffected.

## Tasks

- [x] Add tests
- [x] Update Documentation — does not apply
- [ ] Update `jimp.d.ts` — I suppose irrelevant, as the API is unaffected
- [ ] Add [SemVer](https://semver.org/) Label
