### PR TITLE
Removed Core-JS as a dependency.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ Installation: `npm install --save jimp`
 
 API documentation can be found in the main [jimp package](./packages/jimp)
 
+> ## Notice of potentially breaking change
+>
+> As of v0.10.4, core-js is no longer included with jimp or its extensions. If you rely on core-js, install it with either `yarn add core-js` or `npm i core-js`
+
 ## Tools
 
 :hammer: [cli](./packages/cli) - Jimp as a CLI program. Can load and run all plugins
@@ -70,7 +74,7 @@ Jimp is licensed under the MIT license. Open Sans is licensed under the Apache l
 
 ## Project Using Jimp
 
-:star: [nimp](https://nimp.app/) - Node based image manipulator.  Procedurally create and edit images.
+:star: [nimp](https://nimp.app/) - Node based image manipulator. Procedurally create and edit images.
 
 :star: [favicons](https://www.npmjs.com/package/favicons) - A Node.js module for generating favicons and their associated files.
 

--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,5 @@
   "npmClient": "yarn",
   "registry": "https://registry.npmjs.org/",
   "useWorkspaces": true,
-  "version": "0.10.3"
+  "version": "0.10.4"
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimp/cli",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "jimp on the cli",
   "bin": {
     "jimp": "dist/index.js"
@@ -19,7 +19,7 @@
   "dependencies": {
     "@jimp/custom": "link:../custom",
     "chalk": "^2.4.1",
-    "jimp": "^0.10.3",
+    "jimp": "^0.10.4",
     "log-symbols": "^2.2.0",
     "yargs": "^12.0.2"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -38,7 +38,6 @@
     "@jimp/utils": "link:../utils",
     "any-base": "^1.1.0",
     "buffer": "^5.2.0",
-    "core-js": "^3.4.1",
     "exif-parser": "^0.1.12",
     "file-type": "^9.0.0",
     "load-bmfont": "^1.3.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimp/core",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "Jimp core",
   "main": "dist/index.js",
   "module": "es/index.js",

--- a/packages/custom/package.json
+++ b/packages/custom/package.json
@@ -18,8 +18,7 @@
   "license": "MIT",
   "dependencies": {
     "@babel/runtime": "^7.7.2",
-    "@jimp/core": "link:../core",
-    "core-js": "^3.4.1"
+    "@jimp/core": "link:../core"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/custom/package.json
+++ b/packages/custom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimp/custom",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "Interface to customize jimp configuration",
   "main": "dist/index.js",
   "module": "es/index.js",

--- a/packages/jimp/package.json
+++ b/packages/jimp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jimp",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "An image processing library written entirely in JavaScript (i.e. zero external or native dependencies)",
   "main": "dist/index.js",
   "module": "es/index.js",

--- a/packages/jimp/package.json
+++ b/packages/jimp/package.json
@@ -63,7 +63,6 @@
     "@jimp/custom": "link:../custom",
     "@jimp/plugins": "link:../plugins",
     "@jimp/types": "link:../types",
-    "core-js": "^3.4.1",
     "regenerator-runtime": "^0.13.3"
   },
   "devDependencies": {

--- a/packages/plugin-blit/package.json
+++ b/packages/plugin-blit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimp/plugin-blit",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "Blit an image.",
   "main": "dist/index.js",
   "module": "es/index.js",

--- a/packages/plugin-blit/package.json
+++ b/packages/plugin-blit/package.json
@@ -21,8 +21,7 @@
   "license": "MIT",
   "dependencies": {
     "@babel/runtime": "^7.7.2",
-    "@jimp/utils": "link:../utils",
-    "core-js": "^3.4.1"
+    "@jimp/utils": "link:../utils"
   },
   "devDependencies": {
     "@jimp/custom": "link:../custom",

--- a/packages/plugin-blur/package.json
+++ b/packages/plugin-blur/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimp/plugin-blur",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "blur an image.",
   "main": "dist/index.js",
   "module": "es/index.js",

--- a/packages/plugin-blur/package.json
+++ b/packages/plugin-blur/package.json
@@ -18,8 +18,7 @@
   "license": "MIT",
   "dependencies": {
     "@babel/runtime": "^7.7.2",
-    "@jimp/utils": "link:../utils",
-    "core-js": "^3.4.1"
+    "@jimp/utils": "link:../utils"
   },
   "peerDependencies": {
     "@jimp/custom": ">=0.3.5"

--- a/packages/plugin-circle/package.json
+++ b/packages/plugin-circle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimp/plugin-circle",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "Creates a circle out of an image.",
   "main": "dist/index.js",
   "module": "es/index.js",

--- a/packages/plugin-circle/package.json
+++ b/packages/plugin-circle/package.json
@@ -21,8 +21,7 @@
   "license": "MIT",
   "dependencies": {
     "@babel/runtime": "^7.7.2",
-    "@jimp/utils": "link:../utils",
-    "core-js": "^3.4.1"
+    "@jimp/utils": "link:../utils"
   },
   "peerDependencies": {
     "@jimp/custom": ">=0.3.5"

--- a/packages/plugin-color/package.json
+++ b/packages/plugin-color/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimp/plugin-color",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "Bitmap manipulation to adjust the color in an image.",
   "main": "dist/index.js",
   "module": "es/index.js",

--- a/packages/plugin-color/package.json
+++ b/packages/plugin-color/package.json
@@ -22,7 +22,6 @@
   "dependencies": {
     "@babel/runtime": "^7.7.2",
     "@jimp/utils": "link:../utils",
-    "core-js": "^3.4.1",
     "tinycolor2": "^1.4.1"
   },
   "devDependencies": {

--- a/packages/plugin-contain/package.json
+++ b/packages/plugin-contain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimp/plugin-contain",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "contain an image.",
   "main": "dist/index.js",
   "module": "es/index.js",

--- a/packages/plugin-contain/package.json
+++ b/packages/plugin-contain/package.json
@@ -21,8 +21,7 @@
   "license": "MIT",
   "dependencies": {
     "@babel/runtime": "^7.7.2",
-    "@jimp/utils": "link:../utils",
-    "core-js": "^3.4.1"
+    "@jimp/utils": "link:../utils"
   },
   "peerDependencies": {
     "@jimp/custom": ">=0.3.5",

--- a/packages/plugin-cover/package.json
+++ b/packages/plugin-cover/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimp/plugin-cover",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "cover an image.",
   "main": "dist/index.js",
   "module": "es/index.js",

--- a/packages/plugin-cover/package.json
+++ b/packages/plugin-cover/package.json
@@ -21,8 +21,7 @@
   "license": "MIT",
   "dependencies": {
     "@babel/runtime": "^7.7.2",
-    "@jimp/utils": "link:../utils",
-    "core-js": "^3.4.1"
+    "@jimp/utils": "link:../utils"
   },
   "peerDependencies": {
     "@jimp/custom": ">=0.3.5",

--- a/packages/plugin-crop/package.json
+++ b/packages/plugin-crop/package.json
@@ -21,8 +21,7 @@
   "license": "MIT",
   "dependencies": {
     "@babel/runtime": "^7.7.2",
-    "@jimp/utils": "link:../utils",
-    "core-js": "^3.4.1"
+    "@jimp/utils": "link:../utils"
   },
   "devDependencies": {
     "@jimp/custom": "link:../custom",

--- a/packages/plugin-crop/package.json
+++ b/packages/plugin-crop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimp/plugin-crop",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "crop an image.",
   "main": "dist/index.js",
   "module": "es/index.js",

--- a/packages/plugin-displace/package.json
+++ b/packages/plugin-displace/package.json
@@ -18,8 +18,7 @@
   "license": "MIT",
   "dependencies": {
     "@babel/runtime": "^7.7.2",
-    "@jimp/utils": "link:../utils",
-    "core-js": "^3.4.1"
+    "@jimp/utils": "link:../utils"
   },
   "peerDependencies": {
     "@jimp/custom": ">=0.3.5"

--- a/packages/plugin-displace/package.json
+++ b/packages/plugin-displace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimp/plugin-displace",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "displace an image.",
   "main": "dist/index.js",
   "module": "es/index.js",

--- a/packages/plugin-dither/package.json
+++ b/packages/plugin-dither/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimp/plugin-dither",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "Dither an image.",
   "main": "dist/index.js",
   "module": "es/index.js",

--- a/packages/plugin-dither/package.json
+++ b/packages/plugin-dither/package.json
@@ -18,8 +18,7 @@
   "license": "MIT",
   "dependencies": {
     "@babel/runtime": "^7.7.2",
-    "@jimp/utils": "link:../utils",
-    "core-js": "^3.4.1"
+    "@jimp/utils": "link:../utils"
   },
   "peerDependencies": {
     "@jimp/custom": ">=0.3.5"

--- a/packages/plugin-fisheye/package.json
+++ b/packages/plugin-fisheye/package.json
@@ -21,8 +21,7 @@
   "license": "MIT",
   "dependencies": {
     "@babel/runtime": "^7.7.2",
-    "@jimp/utils": "link:../utils",
-    "core-js": "^3.4.1"
+    "@jimp/utils": "link:../utils"
   },
   "peerDependencies": {
     "@jimp/custom": ">=0.3.5"

--- a/packages/plugin-fisheye/package.json
+++ b/packages/plugin-fisheye/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimp/plugin-fisheye",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "Apply a fisheye effect to an image.",
   "main": "dist/index.js",
   "module": "es/index.js",

--- a/packages/plugin-flip/package.json
+++ b/packages/plugin-flip/package.json
@@ -18,8 +18,7 @@
   "license": "MIT",
   "dependencies": {
     "@babel/runtime": "^7.7.2",
-    "@jimp/utils": "link:../utils",
-    "core-js": "^3.4.1"
+    "@jimp/utils": "link:../utils"
   },
   "peerDependencies": {
     "@jimp/custom": ">=0.3.5",

--- a/packages/plugin-flip/package.json
+++ b/packages/plugin-flip/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimp/plugin-flip",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "flip an image.",
   "main": "dist/index.js",
   "module": "es/index.js",

--- a/packages/plugin-gaussian/package.json
+++ b/packages/plugin-gaussian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimp/plugin-gaussian",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "gaussian blur an image.",
   "main": "dist/index.js",
   "module": "es/index.js",

--- a/packages/plugin-gaussian/package.json
+++ b/packages/plugin-gaussian/package.json
@@ -18,8 +18,7 @@
   "license": "MIT",
   "dependencies": {
     "@babel/runtime": "^7.7.2",
-    "@jimp/utils": "link:../utils",
-    "core-js": "^3.4.1"
+    "@jimp/utils": "link:../utils"
   },
   "peerDependencies": {
     "@jimp/custom": ">=0.3.5"

--- a/packages/plugin-invert/package.json
+++ b/packages/plugin-invert/package.json
@@ -18,8 +18,7 @@
   "license": "MIT",
   "dependencies": {
     "@babel/runtime": "^7.7.2",
-    "@jimp/utils": "link:../utils",
-    "core-js": "^3.4.1"
+    "@jimp/utils": "link:../utils"
   },
   "peerDependencies": {
     "@jimp/custom": ">=0.3.5"

--- a/packages/plugin-invert/package.json
+++ b/packages/plugin-invert/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimp/plugin-invert",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "invert an image.",
   "main": "dist/index.js",
   "module": "es/index.js",

--- a/packages/plugin-mask/package.json
+++ b/packages/plugin-mask/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimp/plugin-mask",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "mask an image.",
   "main": "dist/index.js",
   "module": "es/index.js",

--- a/packages/plugin-mask/package.json
+++ b/packages/plugin-mask/package.json
@@ -21,8 +21,7 @@
   "license": "MIT",
   "dependencies": {
     "@babel/runtime": "^7.7.2",
-    "@jimp/utils": "link:../utils",
-    "core-js": "^3.4.1"
+    "@jimp/utils": "link:../utils"
   },
   "peerDependencies": {
     "@jimp/custom": ">=0.3.5"

--- a/packages/plugin-normalize/package.json
+++ b/packages/plugin-normalize/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimp/plugin-normalize",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "normalize an image.",
   "main": "dist/index.js",
   "module": "es/index.js",

--- a/packages/plugin-normalize/package.json
+++ b/packages/plugin-normalize/package.json
@@ -21,8 +21,7 @@
   "license": "MIT",
   "dependencies": {
     "@babel/runtime": "^7.7.2",
-    "@jimp/utils": "link:../utils",
-    "core-js": "^3.4.1"
+    "@jimp/utils": "link:../utils"
   },
   "peerDependencies": {
     "@jimp/custom": ">=0.3.5"

--- a/packages/plugin-print/package.json
+++ b/packages/plugin-print/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimp/plugin-print",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "print an image.",
   "main": "dist/index.js",
   "module": "es/index.js",

--- a/packages/plugin-print/package.json
+++ b/packages/plugin-print/package.json
@@ -22,7 +22,6 @@
   "dependencies": {
     "@babel/runtime": "^7.7.2",
     "@jimp/utils": "link:../utils",
-    "core-js": "^3.4.1",
     "load-bmfont": "^1.4.0"
   },
   "peerDependencies": {

--- a/packages/plugin-resize/package.json
+++ b/packages/plugin-resize/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimp/plugin-resize",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "Resize an image.",
   "main": "dist/index.js",
   "module": "es/index.js",

--- a/packages/plugin-resize/package.json
+++ b/packages/plugin-resize/package.json
@@ -21,8 +21,7 @@
   "license": "MIT",
   "dependencies": {
     "@babel/runtime": "^7.7.2",
-    "@jimp/utils": "link:../utils",
-    "core-js": "^3.4.1"
+    "@jimp/utils": "link:../utils"
   },
   "peerDependencies": {
     "@jimp/custom": ">=0.3.5"

--- a/packages/plugin-rotate/package.json
+++ b/packages/plugin-rotate/package.json
@@ -21,8 +21,7 @@
   "license": "MIT",
   "dependencies": {
     "@babel/runtime": "^7.7.2",
-    "@jimp/utils": "link:../utils",
-    "core-js": "^3.4.1"
+    "@jimp/utils": "link:../utils"
   },
   "peerDependencies": {
     "@jimp/custom": ">=0.3.5",

--- a/packages/plugin-rotate/package.json
+++ b/packages/plugin-rotate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimp/plugin-rotate",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "Rotate an image.",
   "main": "dist/index.js",
   "module": "es/index.js",

--- a/packages/plugin-scale/package.json
+++ b/packages/plugin-scale/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimp/plugin-scale",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "scale an image.",
   "main": "dist/index.js",
   "module": "es/index.js",

--- a/packages/plugin-scale/package.json
+++ b/packages/plugin-scale/package.json
@@ -18,8 +18,7 @@
   "license": "MIT",
   "dependencies": {
     "@babel/runtime": "^7.7.2",
-    "@jimp/utils": "link:../utils",
-    "core-js": "^3.4.1"
+    "@jimp/utils": "link:../utils"
   },
   "peerDependencies": {
     "@jimp/custom": ">=0.3.5",

--- a/packages/plugin-shadow/package.json
+++ b/packages/plugin-shadow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimp/plugin-shadow",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "Creates a shadow on an image.",
   "main": "dist/index.js",
   "module": "es/index.js",

--- a/packages/plugin-shadow/package.json
+++ b/packages/plugin-shadow/package.json
@@ -21,8 +21,7 @@
   "license": "MIT",
   "dependencies": {
     "@babel/runtime": "^7.7.2",
-    "@jimp/utils": "link:../utils",
-    "core-js": "^3.4.1"
+    "@jimp/utils": "link:../utils"
   },
   "peerDependencies": {
     "@jimp/custom": ">=0.3.5",

--- a/packages/plugin-threshold/package.json
+++ b/packages/plugin-threshold/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimp/plugin-threshold",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "Lightens an image.",
   "main": "dist/index.js",
   "module": "es/index.js",

--- a/packages/plugin-threshold/package.json
+++ b/packages/plugin-threshold/package.json
@@ -21,8 +21,7 @@
   "license": "MIT",
   "dependencies": {
     "@babel/runtime": "^7.7.2",
-    "@jimp/utils": "link:../utils",
-    "core-js": "^3.4.1"
+    "@jimp/utils": "link:../utils"
   },
   "peerDependencies": {
     "@jimp/custom": ">=0.3.5",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimp/plugins",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "Default Jimp plugin.",
   "main": "dist/index.js",
   "module": "es/index.js",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -39,7 +39,6 @@
     "@jimp/plugin-scale": "link:../plugin-scale",
     "@jimp/plugin-shadow": "link:../plugin-shadow",
     "@jimp/plugin-threshold": "link:../plugin-threshold",
-    "core-js": "^3.4.1",
     "timm": "^1.6.1"
   },
   "peerDependencies": {

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimp/test-utils",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "Test utils for jimp extensions.",
   "main": "dist/index.js",
   "module": "es/index.js",

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -23,7 +23,6 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.7.2",
-    "core-js": "^3.4.1",
     "pngjs": "^3.3.3"
   },
   "devDependencies": {

--- a/packages/type-bmp/package.json
+++ b/packages/type-bmp/package.json
@@ -22,8 +22,7 @@
   "dependencies": {
     "@babel/runtime": "^7.7.2",
     "@jimp/utils": "link:../utils",
-    "bmp-js": "^0.1.0",
-    "core-js": "^3.4.1"
+    "bmp-js": "^0.1.0"
   },
   "peerDependencies": {
     "@jimp/custom": ">=0.3.5"

--- a/packages/type-bmp/package.json
+++ b/packages/type-bmp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimp/bmp",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "Default Jimp bmp encoder/decoder.",
   "main": "dist/index.js",
   "module": "es/index.js",

--- a/packages/type-gif/package.json
+++ b/packages/type-gif/package.json
@@ -19,7 +19,6 @@
   "dependencies": {
     "@babel/runtime": "^7.7.2",
     "@jimp/utils": "link:../utils",
-    "core-js": "^3.4.1",
     "omggif": "^1.0.9"
   },
   "peerDependencies": {

--- a/packages/type-gif/package.json
+++ b/packages/type-gif/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimp/gif",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "Default Jimp gif encoder/decoder.",
   "main": "dist/index.js",
   "module": "es/index.js",

--- a/packages/type-jpeg/package.json
+++ b/packages/type-jpeg/package.json
@@ -22,7 +22,6 @@
   "dependencies": {
     "@babel/runtime": "^7.7.2",
     "@jimp/utils": "link:../utils",
-    "core-js": "^3.4.1",
     "jpeg-js": "^0.3.4"
   },
   "peerDependencies": {

--- a/packages/type-jpeg/package.json
+++ b/packages/type-jpeg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimp/jpeg",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "Default Jimp jpeg encoder/decoder.",
   "main": "dist/index.js",
   "module": "es/index.js",

--- a/packages/type-png/package.json
+++ b/packages/type-png/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimp/png",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "Default Jimp png encoder/decoder.",
   "main": "dist/index.js",
   "module": "es/index.js",

--- a/packages/type-png/package.json
+++ b/packages/type-png/package.json
@@ -22,7 +22,6 @@
   "dependencies": {
     "@babel/runtime": "^7.7.2",
     "@jimp/utils": "link:../utils",
-    "core-js": "^3.4.1",
     "pngjs": "^3.3.3"
   },
   "peerDependencies": {

--- a/packages/type-tiff/package.json
+++ b/packages/type-tiff/package.json
@@ -21,7 +21,6 @@
   "license": "MIT",
   "dependencies": {
     "@babel/runtime": "^7.7.2",
-    "core-js": "^3.4.1",
     "utif": "^2.0.1"
   },
   "peerDependencies": {

--- a/packages/type-tiff/package.json
+++ b/packages/type-tiff/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimp/tiff",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "Default Jimp tiff encoder/decoder.",
   "main": "dist/index.js",
   "module": "es/index.js",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -23,7 +23,6 @@
     "@jimp/jpeg": "link:../type-jpeg",
     "@jimp/png": "link:../type-png",
     "@jimp/tiff": "link:../type-tiff",
-    "core-js": "^3.4.1",
     "timm": "^1.6.1"
   },
   "peerDependencies": {

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimp/types",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "Default Jimp encoder/decoders.",
   "main": "dist/index.js",
   "module": "es/index.js",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -21,7 +21,6 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.7.2",
-    "core-js": "^3.4.1",
     "regenerator-runtime": "^0.13.3"
   }
 }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimp/utils",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "Utils for jimp extensions.",
   "main": "dist/index.js",
   "module": "es/index.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1008,21 +1008,19 @@
     which "^1.3.1"
 
 "@jimp/bmp@link:packages/type-bmp":
-  version "0.9.6"
+  version "0.10.3"
   dependencies:
     "@babel/runtime" "^7.7.2"
     "@jimp/utils" "link:packages/utils"
     bmp-js "^0.1.0"
-    core-js "^3.4.1"
 
 "@jimp/core@link:packages/core":
-  version "0.9.6"
+  version "0.10.3"
   dependencies:
     "@babel/runtime" "^7.7.2"
     "@jimp/utils" "link:packages/utils"
     any-base "^1.1.0"
     buffer "^5.2.0"
-    core-js "^3.4.1"
     exif-parser "^0.1.12"
     file-type "^9.0.0"
     load-bmfont "^1.3.1"
@@ -1032,161 +1030,167 @@
     tinycolor2 "^1.4.1"
 
 "@jimp/custom@link:packages/custom":
-  version "0.9.6"
+  version "0.10.3"
   dependencies:
     "@babel/runtime" "^7.7.2"
     "@jimp/core" "link:packages/core"
-    core-js "^3.4.1"
 
 "@jimp/gif@link:packages/type-gif":
-  version "0.9.6"
+  version "0.10.3"
   dependencies:
     "@babel/runtime" "^7.7.2"
     "@jimp/utils" "link:packages/utils"
-    core-js "^3.4.1"
     omggif "^1.0.9"
 
 "@jimp/jpeg@link:packages/type-jpeg":
-  version "0.9.6"
+  version "0.10.3"
   dependencies:
     "@babel/runtime" "^7.7.2"
     "@jimp/utils" "link:packages/utils"
-    core-js "^3.4.1"
     jpeg-js "^0.3.4"
 
 "@jimp/plugin-blit@link:packages/plugin-blit":
-  version "0.9.6"
+  version "0.10.3"
   dependencies:
     "@babel/runtime" "^7.7.2"
     "@jimp/utils" "link:packages/utils"
-    core-js "^3.4.1"
 
 "@jimp/plugin-blur@link:packages/plugin-blur":
-  version "0.9.6"
+  version "0.10.3"
   dependencies:
     "@babel/runtime" "^7.7.2"
     "@jimp/utils" "link:packages/utils"
-    core-js "^3.4.1"
+
+"@jimp/plugin-circle@link:packages/plugin-circle":
+  version "0.10.3"
+  dependencies:
+    "@babel/runtime" "^7.7.2"
+    "@jimp/utils" "link:packages/utils"
 
 "@jimp/plugin-color@link:packages/plugin-color":
-  version "0.9.6"
+  version "0.10.3"
   dependencies:
     "@babel/runtime" "^7.7.2"
     "@jimp/utils" "link:packages/utils"
-    core-js "^3.4.1"
     tinycolor2 "^1.4.1"
 
 "@jimp/plugin-contain@link:packages/plugin-contain":
-  version "0.9.6"
+  version "0.10.3"
   dependencies:
     "@babel/runtime" "^7.7.2"
     "@jimp/utils" "link:packages/utils"
-    core-js "^3.4.1"
 
 "@jimp/plugin-cover@link:packages/plugin-cover":
-  version "0.9.6"
+  version "0.10.3"
   dependencies:
     "@babel/runtime" "^7.7.2"
     "@jimp/utils" "link:packages/utils"
-    core-js "^3.4.1"
 
 "@jimp/plugin-crop@link:packages/plugin-crop":
-  version "0.9.6"
+  version "0.10.3"
   dependencies:
     "@babel/runtime" "^7.7.2"
     "@jimp/utils" "link:packages/utils"
-    core-js "^3.4.1"
 
 "@jimp/plugin-displace@link:packages/plugin-displace":
-  version "0.9.6"
+  version "0.10.3"
   dependencies:
     "@babel/runtime" "^7.7.2"
     "@jimp/utils" "link:packages/utils"
-    core-js "^3.4.1"
 
 "@jimp/plugin-dither@link:packages/plugin-dither":
-  version "0.9.6"
+  version "0.10.3"
   dependencies:
     "@babel/runtime" "^7.7.2"
     "@jimp/utils" "link:packages/utils"
-    core-js "^3.4.1"
+
+"@jimp/plugin-fisheye@link:packages/plugin-fisheye":
+  version "0.10.3"
+  dependencies:
+    "@babel/runtime" "^7.7.2"
+    "@jimp/utils" "link:packages/utils"
 
 "@jimp/plugin-flip@link:packages/plugin-flip":
-  version "0.9.6"
+  version "0.10.3"
   dependencies:
     "@babel/runtime" "^7.7.2"
     "@jimp/utils" "link:packages/utils"
-    core-js "^3.4.1"
 
 "@jimp/plugin-gaussian@link:packages/plugin-gaussian":
-  version "0.9.6"
+  version "0.10.3"
   dependencies:
     "@babel/runtime" "^7.7.2"
     "@jimp/utils" "link:packages/utils"
-    core-js "^3.4.1"
 
 "@jimp/plugin-invert@link:packages/plugin-invert":
-  version "0.9.6"
+  version "0.10.3"
   dependencies:
     "@babel/runtime" "^7.7.2"
     "@jimp/utils" "link:packages/utils"
-    core-js "^3.4.1"
 
 "@jimp/plugin-mask@link:packages/plugin-mask":
-  version "0.9.6"
+  version "0.10.3"
   dependencies:
     "@babel/runtime" "^7.7.2"
     "@jimp/utils" "link:packages/utils"
-    core-js "^3.4.1"
 
 "@jimp/plugin-normalize@link:packages/plugin-normalize":
-  version "0.9.6"
+  version "0.10.3"
   dependencies:
     "@babel/runtime" "^7.7.2"
     "@jimp/utils" "link:packages/utils"
-    core-js "^3.4.1"
 
 "@jimp/plugin-print@link:packages/plugin-print":
-  version "0.9.6"
+  version "0.10.3"
   dependencies:
     "@babel/runtime" "^7.7.2"
     "@jimp/utils" "link:packages/utils"
-    core-js "^3.4.1"
     load-bmfont "^1.4.0"
 
 "@jimp/plugin-resize@link:packages/plugin-resize":
-  version "0.9.6"
+  version "0.10.3"
   dependencies:
     "@babel/runtime" "^7.7.2"
     "@jimp/utils" "link:packages/utils"
-    core-js "^3.4.1"
 
 "@jimp/plugin-rotate@link:packages/plugin-rotate":
-  version "0.9.6"
+  version "0.10.3"
   dependencies:
     "@babel/runtime" "^7.7.2"
     "@jimp/utils" "link:packages/utils"
-    core-js "^3.4.1"
 
 "@jimp/plugin-scale@link:packages/plugin-scale":
-  version "0.9.6"
+  version "0.10.3"
   dependencies:
     "@babel/runtime" "^7.7.2"
     "@jimp/utils" "link:packages/utils"
-    core-js "^3.4.1"
+
+"@jimp/plugin-shadow@link:packages/plugin-shadow":
+  version "0.10.3"
+  dependencies:
+    "@babel/runtime" "^7.7.2"
+    "@jimp/utils" "link:packages/utils"
+
+"@jimp/plugin-threshold@link:packages/plugin-threshold":
+  version "0.10.3"
+  dependencies:
+    "@babel/runtime" "^7.7.2"
+    "@jimp/utils" "link:packages/utils"
 
 "@jimp/plugins@link:packages/plugins":
-  version "0.9.6"
+  version "0.10.3"
   dependencies:
     "@babel/runtime" "^7.7.2"
     "@jimp/plugin-blit" "link:packages/plugin-blit"
     "@jimp/plugin-blur" "link:packages/plugin-blur"
+    "@jimp/plugin-circle" "link:packages/plugin-circle"
     "@jimp/plugin-color" "link:packages/plugin-color"
     "@jimp/plugin-contain" "link:packages/plugin-contain"
     "@jimp/plugin-cover" "link:packages/plugin-cover"
     "@jimp/plugin-crop" "link:packages/plugin-crop"
     "@jimp/plugin-displace" "link:packages/plugin-displace"
     "@jimp/plugin-dither" "link:packages/plugin-dither"
+    "@jimp/plugin-fisheye" "link:packages/plugin-fisheye"
     "@jimp/plugin-flip" "link:packages/plugin-flip"
     "@jimp/plugin-gaussian" "link:packages/plugin-gaussian"
     "@jimp/plugin-invert" "link:packages/plugin-invert"
@@ -1196,33 +1200,31 @@
     "@jimp/plugin-resize" "link:packages/plugin-resize"
     "@jimp/plugin-rotate" "link:packages/plugin-rotate"
     "@jimp/plugin-scale" "link:packages/plugin-scale"
-    core-js "^3.4.1"
+    "@jimp/plugin-shadow" "link:packages/plugin-shadow"
+    "@jimp/plugin-threshold" "link:packages/plugin-threshold"
     timm "^1.6.1"
 
 "@jimp/png@link:packages/type-png":
-  version "0.9.6"
+  version "0.10.3"
   dependencies:
     "@babel/runtime" "^7.7.2"
     "@jimp/utils" "link:packages/utils"
-    core-js "^3.4.1"
     pngjs "^3.3.3"
 
 "@jimp/test-utils@link:packages/test-utils":
-  version "0.9.6"
+  version "0.10.3"
   dependencies:
     "@babel/runtime" "^7.7.2"
-    core-js "^3.4.1"
     pngjs "^3.3.3"
 
 "@jimp/tiff@link:packages/type-tiff":
-  version "0.9.6"
+  version "0.10.3"
   dependencies:
     "@babel/runtime" "^7.7.2"
-    core-js "^3.4.1"
     utif "^2.0.1"
 
 "@jimp/types@link:packages/types":
-  version "0.9.6"
+  version "0.10.3"
   dependencies:
     "@babel/runtime" "^7.7.2"
     "@jimp/bmp" "link:packages/type-bmp"
@@ -1230,14 +1232,13 @@
     "@jimp/jpeg" "link:packages/type-jpeg"
     "@jimp/png" "link:packages/type-png"
     "@jimp/tiff" "link:packages/type-tiff"
-    core-js "^3.4.1"
     timm "^1.6.1"
 
 "@jimp/utils@link:packages/utils":
-  version "0.9.6"
+  version "0.10.3"
   dependencies:
     "@babel/runtime" "^7.7.2"
-    core-js "^3.4.1"
+    regenerator-runtime "^0.13.3"
 
 "@lerna/add@3.16.2":
   version "3.16.2"
@@ -3855,11 +3856,6 @@ core-js@^3.1.3:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.2.1.tgz#cd41f38534da6cc59f7db050fe67307de9868b09"
   integrity sha512-Qa5XSVefSVPRxy2XfUC13WbvqkxhkwB3ve+pgCQveNgYzbM/UxZeu1dcOX/xr4UmfUd+muuvsaxilQzCyUurMw==
-
-core-js@^3.4.1:
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.4.1.tgz#76dd6828412900ab27c8ce0b22e6114d7ce21b18"
-  integrity sha512-KX/dnuY/J8FtEwbnrzmAjUYgLqtk+cxM86hfG60LGiW3MmltIc2yAmDgBgEkfm0blZhUrdr1Zd84J2Y14mLxzg==
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"


### PR DESCRIPTION
# What's Changing and Why
I removed Core-JS as a dependency, per #769 
It is not the responsibility of this library to polyfill the environment of a developer - it is the responsibility of the developer to polyfill their environment as they see fit.
The longest part of my install in projects that use jimp is getting spammed with 30 messages from core-js to either update or donate.

In the words of @laino,
> This is not something you should do for the user of your library, **ever**.
> 
> It's my job to provide your lib an environment it can run in, it's not the job of an image library to go messing with it.
>
> Let me worry about polyfilling stuff or not polyfilling stuff. Now I have to ship core-js just to get jimp working.
>
> Maybe have a `@jimp/polyfills` repo if you want to provide auto-polyfilling.

## What else might be affected
People working in environments where they don't explicitly depend on core-js will have to explicitly install core-js if they still need it.

## Tasks

- [x] Add tests (n/a - this simply removes polyfilling, and all tests passed)
- [x] Update Documentation
- [x] Update `jimp.d.ts` (n/a - no types are affected by this)
- [x] Add [SemVer](https://semver.org/) Label

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.10.5-canary.882.886.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @jimp/cli@0.10.5-canary.882.886.0
  npm install @jimp/core@0.10.5-canary.882.886.0
  npm install @jimp/custom@0.10.5-canary.882.886.0
  npm install jimp@0.10.5-canary.882.886.0
  npm install @jimp/plugin-blit@0.10.5-canary.882.886.0
  npm install @jimp/plugin-blur@0.10.5-canary.882.886.0
  npm install @jimp/plugin-circle@0.10.5-canary.882.886.0
  npm install @jimp/plugin-color@0.10.5-canary.882.886.0
  npm install @jimp/plugin-contain@0.10.5-canary.882.886.0
  npm install @jimp/plugin-cover@0.10.5-canary.882.886.0
  npm install @jimp/plugin-crop@0.10.5-canary.882.886.0
  npm install @jimp/plugin-displace@0.10.5-canary.882.886.0
  npm install @jimp/plugin-dither@0.10.5-canary.882.886.0
  npm install @jimp/plugin-fisheye@0.10.5-canary.882.886.0
  npm install @jimp/plugin-flip@0.10.5-canary.882.886.0
  npm install @jimp/plugin-gaussian@0.10.5-canary.882.886.0
  npm install @jimp/plugin-invert@0.10.5-canary.882.886.0
  npm install @jimp/plugin-mask@0.10.5-canary.882.886.0
  npm install @jimp/plugin-normalize@0.10.5-canary.882.886.0
  npm install @jimp/plugin-print@0.10.5-canary.882.886.0
  npm install @jimp/plugin-resize@0.10.5-canary.882.886.0
  npm install @jimp/plugin-rotate@0.10.5-canary.882.886.0
  npm install @jimp/plugin-scale@0.10.5-canary.882.886.0
  npm install @jimp/plugin-shadow@0.10.5-canary.882.886.0
  npm install @jimp/plugin-threshold@0.10.5-canary.882.886.0
  npm install @jimp/plugins@0.10.5-canary.882.886.0
  npm install @jimp/test-utils@0.10.5-canary.882.886.0
  npm install @jimp/bmp@0.10.5-canary.882.886.0
  npm install @jimp/gif@0.10.5-canary.882.886.0
  npm install @jimp/jpeg@0.10.5-canary.882.886.0
  npm install @jimp/png@0.10.5-canary.882.886.0
  npm install @jimp/tiff@0.10.5-canary.882.886.0
  npm install @jimp/types@0.10.5-canary.882.886.0
  npm install @jimp/utils@0.10.5-canary.882.886.0
  # or 
  yarn add @jimp/cli@0.10.5-canary.882.886.0
  yarn add @jimp/core@0.10.5-canary.882.886.0
  yarn add @jimp/custom@0.10.5-canary.882.886.0
  yarn add jimp@0.10.5-canary.882.886.0
  yarn add @jimp/plugin-blit@0.10.5-canary.882.886.0
  yarn add @jimp/plugin-blur@0.10.5-canary.882.886.0
  yarn add @jimp/plugin-circle@0.10.5-canary.882.886.0
  yarn add @jimp/plugin-color@0.10.5-canary.882.886.0
  yarn add @jimp/plugin-contain@0.10.5-canary.882.886.0
  yarn add @jimp/plugin-cover@0.10.5-canary.882.886.0
  yarn add @jimp/plugin-crop@0.10.5-canary.882.886.0
  yarn add @jimp/plugin-displace@0.10.5-canary.882.886.0
  yarn add @jimp/plugin-dither@0.10.5-canary.882.886.0
  yarn add @jimp/plugin-fisheye@0.10.5-canary.882.886.0
  yarn add @jimp/plugin-flip@0.10.5-canary.882.886.0
  yarn add @jimp/plugin-gaussian@0.10.5-canary.882.886.0
  yarn add @jimp/plugin-invert@0.10.5-canary.882.886.0
  yarn add @jimp/plugin-mask@0.10.5-canary.882.886.0
  yarn add @jimp/plugin-normalize@0.10.5-canary.882.886.0
  yarn add @jimp/plugin-print@0.10.5-canary.882.886.0
  yarn add @jimp/plugin-resize@0.10.5-canary.882.886.0
  yarn add @jimp/plugin-rotate@0.10.5-canary.882.886.0
  yarn add @jimp/plugin-scale@0.10.5-canary.882.886.0
  yarn add @jimp/plugin-shadow@0.10.5-canary.882.886.0
  yarn add @jimp/plugin-threshold@0.10.5-canary.882.886.0
  yarn add @jimp/plugins@0.10.5-canary.882.886.0
  yarn add @jimp/test-utils@0.10.5-canary.882.886.0
  yarn add @jimp/bmp@0.10.5-canary.882.886.0
  yarn add @jimp/gif@0.10.5-canary.882.886.0
  yarn add @jimp/jpeg@0.10.5-canary.882.886.0
  yarn add @jimp/png@0.10.5-canary.882.886.0
  yarn add @jimp/tiff@0.10.5-canary.882.886.0
  yarn add @jimp/types@0.10.5-canary.882.886.0
  yarn add @jimp/utils@0.10.5-canary.882.886.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
