### PR TITLE
Make callback optional for Jimp.rgbaToInt

### DIFF
--- a/packages/core/types/jimp.d.ts
+++ b/packages/core/types/jimp.d.ts
@@ -99,7 +99,7 @@ export interface JimpConstructors {
     g: number,
     b: number,
     a: number,
-    cb: GenericCallback<number, any, this['prototype']>
+    cb?: GenericCallback<number, any, this['prototype']>
   ): number;
   intToRGBA(i: number, cb?: GenericCallback<RGBA>): RGBA;
   cssColorToHex(cssColor: string): number;


### PR DESCRIPTION
# What's Changing and Why

Made an method argument optional in the the typings.

## What else might be affected

I don't think much will be affected.

## Tasks

- [x] Add tests
- [x] Update Documentation
- [x] Update `jimp.d.ts`
- [ ] Add [SemVer](https://semver.org/) Label

See #888 
