### PR TITLE
Remove compiling polyfills into published code

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,22 +44,6 @@ jobs:
           name: Test Types
           command: yarn tsTest:custom && yarn tsTest:main
 
-  build-node6.14:
-    working_directory: ~/jimp-6.14
-    docker:
-      - image: circleci/node:6.14-browsers
-    steps:
-      - checkout
-      - run:
-          name: Install Dependencies
-          command: yarn install --frozen-lockfile --network-timeout 100000  --ignore-engines
-      - run:
-          name: Build Packages
-          command: yarn build
-      - run:
-          name: Test
-          command: yarn test --ci
-
   build-node8:
     <<: *defaults
     steps:
@@ -117,11 +101,6 @@ workflows:
       - test-types:
           requires:
             - install
-
-      - build-node6.14:
-          requires:
-            - lint
-            - test-types
 
       - build-node8:
           requires:

--- a/babel.config.js
+++ b/babel.config.js
@@ -3,13 +3,7 @@ module.exports = api => {
 
   return {
     presets: [
-      [
-        '@babel/preset-env',
-        {
-          useBuiltIns: 'usage',
-          corejs: 3
-        }
-      ]
+      '@babel/preset-env',
     ],
 
     plugins: [


### PR DESCRIPTION
# What's Changing and Why

After core-js has been removed jimp does not work anymore out of the box as core-js is still required in the compiled output. By removing the corejs configuration from the babel config it will not be compiled into the output anymore and start working again.

Fixes #890 


## Release Notes

This also drops support for node 6.14.

## Tasks

- [ ] Add tests
- [ ] Update Documentation
- [ ] Update `jimp.d.ts`
- [ ] Add [SemVer](https://semver.org/) Label

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.11.1-canary.891.908.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @jimp/cli@0.11.1-canary.891.908.0
  npm install @jimp/core@0.11.1-canary.891.908.0
  npm install @jimp/custom@0.11.1-canary.891.908.0
  npm install jimp@0.11.1-canary.891.908.0
  npm install @jimp/plugin-blit@0.11.1-canary.891.908.0
  npm install @jimp/plugin-blur@0.11.1-canary.891.908.0
  npm install @jimp/plugin-circle@0.11.1-canary.891.908.0
  npm install @jimp/plugin-color@0.11.1-canary.891.908.0
  npm install @jimp/plugin-contain@0.11.1-canary.891.908.0
  npm install @jimp/plugin-cover@0.11.1-canary.891.908.0
  npm install @jimp/plugin-crop@0.11.1-canary.891.908.0
  npm install @jimp/plugin-displace@0.11.1-canary.891.908.0
  npm install @jimp/plugin-dither@0.11.1-canary.891.908.0
  npm install @jimp/plugin-fisheye@0.11.1-canary.891.908.0
  npm install @jimp/plugin-flip@0.11.1-canary.891.908.0
  npm install @jimp/plugin-gaussian@0.11.1-canary.891.908.0
  npm install @jimp/plugin-invert@0.11.1-canary.891.908.0
  npm install @jimp/plugin-mask@0.11.1-canary.891.908.0
  npm install @jimp/plugin-normalize@0.11.1-canary.891.908.0
  npm install @jimp/plugin-print@0.11.1-canary.891.908.0
  npm install @jimp/plugin-resize@0.11.1-canary.891.908.0
  npm install @jimp/plugin-rotate@0.11.1-canary.891.908.0
  npm install @jimp/plugin-scale@0.11.1-canary.891.908.0
  npm install @jimp/plugin-shadow@0.11.1-canary.891.908.0
  npm install @jimp/plugin-threshold@0.11.1-canary.891.908.0
  npm install @jimp/plugins@0.11.1-canary.891.908.0
  npm install @jimp/test-utils@0.11.1-canary.891.908.0
  npm install @jimp/bmp@0.11.1-canary.891.908.0
  npm install @jimp/gif@0.11.1-canary.891.908.0
  npm install @jimp/jpeg@0.11.1-canary.891.908.0
  npm install @jimp/png@0.11.1-canary.891.908.0
  npm install @jimp/tiff@0.11.1-canary.891.908.0
  npm install @jimp/types@0.11.1-canary.891.908.0
  npm install @jimp/utils@0.11.1-canary.891.908.0
  # or 
  yarn add @jimp/cli@0.11.1-canary.891.908.0
  yarn add @jimp/core@0.11.1-canary.891.908.0
  yarn add @jimp/custom@0.11.1-canary.891.908.0
  yarn add jimp@0.11.1-canary.891.908.0
  yarn add @jimp/plugin-blit@0.11.1-canary.891.908.0
  yarn add @jimp/plugin-blur@0.11.1-canary.891.908.0
  yarn add @jimp/plugin-circle@0.11.1-canary.891.908.0
  yarn add @jimp/plugin-color@0.11.1-canary.891.908.0
  yarn add @jimp/plugin-contain@0.11.1-canary.891.908.0
  yarn add @jimp/plugin-cover@0.11.1-canary.891.908.0
  yarn add @jimp/plugin-crop@0.11.1-canary.891.908.0
  yarn add @jimp/plugin-displace@0.11.1-canary.891.908.0
  yarn add @jimp/plugin-dither@0.11.1-canary.891.908.0
  yarn add @jimp/plugin-fisheye@0.11.1-canary.891.908.0
  yarn add @jimp/plugin-flip@0.11.1-canary.891.908.0
  yarn add @jimp/plugin-gaussian@0.11.1-canary.891.908.0
  yarn add @jimp/plugin-invert@0.11.1-canary.891.908.0
  yarn add @jimp/plugin-mask@0.11.1-canary.891.908.0
  yarn add @jimp/plugin-normalize@0.11.1-canary.891.908.0
  yarn add @jimp/plugin-print@0.11.1-canary.891.908.0
  yarn add @jimp/plugin-resize@0.11.1-canary.891.908.0
  yarn add @jimp/plugin-rotate@0.11.1-canary.891.908.0
  yarn add @jimp/plugin-scale@0.11.1-canary.891.908.0
  yarn add @jimp/plugin-shadow@0.11.1-canary.891.908.0
  yarn add @jimp/plugin-threshold@0.11.1-canary.891.908.0
  yarn add @jimp/plugins@0.11.1-canary.891.908.0
  yarn add @jimp/test-utils@0.11.1-canary.891.908.0
  yarn add @jimp/bmp@0.11.1-canary.891.908.0
  yarn add @jimp/gif@0.11.1-canary.891.908.0
  yarn add @jimp/jpeg@0.11.1-canary.891.908.0
  yarn add @jimp/png@0.11.1-canary.891.908.0
  yarn add @jimp/tiff@0.11.1-canary.891.908.0
  yarn add @jimp/types@0.11.1-canary.891.908.0
  yarn add @jimp/utils@0.11.1-canary.891.908.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
