### PR TITLE
update jpeg-js

### DIFF
--- a/packages/type-jpeg/package.json
+++ b/packages/type-jpeg/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@babel/runtime": "^7.7.2",
     "@jimp/utils": "link:../utils",
-    "jpeg-js": "^0.3.4"
+    "jpeg-js": "^0.4.0"
   },
   "peerDependencies": {
     "@jimp/custom": ">=0.3.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1008,14 +1008,14 @@
     which "^1.3.1"
 
 "@jimp/bmp@link:packages/type-bmp":
-  version "0.10.3"
+  version "0.12.0"
   dependencies:
     "@babel/runtime" "^7.7.2"
     "@jimp/utils" "link:packages/utils"
     bmp-js "^0.1.0"
 
 "@jimp/core@link:packages/core":
-  version "0.10.3"
+  version "0.12.0"
   dependencies:
     "@babel/runtime" "^7.7.2"
     "@jimp/utils" "link:packages/utils"
@@ -1030,155 +1030,155 @@
     tinycolor2 "^1.4.1"
 
 "@jimp/custom@link:packages/custom":
-  version "0.10.3"
+  version "0.12.0"
   dependencies:
     "@babel/runtime" "^7.7.2"
     "@jimp/core" "link:packages/core"
 
 "@jimp/gif@link:packages/type-gif":
-  version "0.10.3"
+  version "0.12.0"
   dependencies:
     "@babel/runtime" "^7.7.2"
     "@jimp/utils" "link:packages/utils"
     omggif "^1.0.9"
 
 "@jimp/jpeg@link:packages/type-jpeg":
-  version "0.10.3"
+  version "0.12.0"
   dependencies:
     "@babel/runtime" "^7.7.2"
     "@jimp/utils" "link:packages/utils"
     jpeg-js "^0.3.4"
 
 "@jimp/plugin-blit@link:packages/plugin-blit":
-  version "0.10.3"
+  version "0.12.0"
   dependencies:
     "@babel/runtime" "^7.7.2"
     "@jimp/utils" "link:packages/utils"
 
 "@jimp/plugin-blur@link:packages/plugin-blur":
-  version "0.10.3"
+  version "0.12.0"
   dependencies:
     "@babel/runtime" "^7.7.2"
     "@jimp/utils" "link:packages/utils"
 
 "@jimp/plugin-circle@link:packages/plugin-circle":
-  version "0.10.3"
+  version "0.12.0"
   dependencies:
     "@babel/runtime" "^7.7.2"
     "@jimp/utils" "link:packages/utils"
 
 "@jimp/plugin-color@link:packages/plugin-color":
-  version "0.10.3"
+  version "0.12.0"
   dependencies:
     "@babel/runtime" "^7.7.2"
     "@jimp/utils" "link:packages/utils"
     tinycolor2 "^1.4.1"
 
 "@jimp/plugin-contain@link:packages/plugin-contain":
-  version "0.10.3"
+  version "0.12.0"
   dependencies:
     "@babel/runtime" "^7.7.2"
     "@jimp/utils" "link:packages/utils"
 
 "@jimp/plugin-cover@link:packages/plugin-cover":
-  version "0.10.3"
+  version "0.12.0"
   dependencies:
     "@babel/runtime" "^7.7.2"
     "@jimp/utils" "link:packages/utils"
 
 "@jimp/plugin-crop@link:packages/plugin-crop":
-  version "0.10.3"
+  version "0.12.0"
   dependencies:
     "@babel/runtime" "^7.7.2"
     "@jimp/utils" "link:packages/utils"
 
 "@jimp/plugin-displace@link:packages/plugin-displace":
-  version "0.10.3"
+  version "0.12.0"
   dependencies:
     "@babel/runtime" "^7.7.2"
     "@jimp/utils" "link:packages/utils"
 
 "@jimp/plugin-dither@link:packages/plugin-dither":
-  version "0.10.3"
+  version "0.12.0"
   dependencies:
     "@babel/runtime" "^7.7.2"
     "@jimp/utils" "link:packages/utils"
 
 "@jimp/plugin-fisheye@link:packages/plugin-fisheye":
-  version "0.10.3"
+  version "0.12.0"
   dependencies:
     "@babel/runtime" "^7.7.2"
     "@jimp/utils" "link:packages/utils"
 
 "@jimp/plugin-flip@link:packages/plugin-flip":
-  version "0.10.3"
+  version "0.12.0"
   dependencies:
     "@babel/runtime" "^7.7.2"
     "@jimp/utils" "link:packages/utils"
 
 "@jimp/plugin-gaussian@link:packages/plugin-gaussian":
-  version "0.10.3"
+  version "0.12.0"
   dependencies:
     "@babel/runtime" "^7.7.2"
     "@jimp/utils" "link:packages/utils"
 
 "@jimp/plugin-invert@link:packages/plugin-invert":
-  version "0.10.3"
+  version "0.12.0"
   dependencies:
     "@babel/runtime" "^7.7.2"
     "@jimp/utils" "link:packages/utils"
 
 "@jimp/plugin-mask@link:packages/plugin-mask":
-  version "0.10.3"
+  version "0.12.0"
   dependencies:
     "@babel/runtime" "^7.7.2"
     "@jimp/utils" "link:packages/utils"
 
 "@jimp/plugin-normalize@link:packages/plugin-normalize":
-  version "0.10.3"
+  version "0.12.0"
   dependencies:
     "@babel/runtime" "^7.7.2"
     "@jimp/utils" "link:packages/utils"
 
 "@jimp/plugin-print@link:packages/plugin-print":
-  version "0.10.3"
+  version "0.12.0"
   dependencies:
     "@babel/runtime" "^7.7.2"
     "@jimp/utils" "link:packages/utils"
     load-bmfont "^1.4.0"
 
 "@jimp/plugin-resize@link:packages/plugin-resize":
-  version "0.10.3"
+  version "0.12.0"
   dependencies:
     "@babel/runtime" "^7.7.2"
     "@jimp/utils" "link:packages/utils"
 
 "@jimp/plugin-rotate@link:packages/plugin-rotate":
-  version "0.10.3"
+  version "0.12.0"
   dependencies:
     "@babel/runtime" "^7.7.2"
     "@jimp/utils" "link:packages/utils"
 
 "@jimp/plugin-scale@link:packages/plugin-scale":
-  version "0.10.3"
+  version "0.12.0"
   dependencies:
     "@babel/runtime" "^7.7.2"
     "@jimp/utils" "link:packages/utils"
 
 "@jimp/plugin-shadow@link:packages/plugin-shadow":
-  version "0.10.3"
+  version "0.12.0"
   dependencies:
     "@babel/runtime" "^7.7.2"
     "@jimp/utils" "link:packages/utils"
 
 "@jimp/plugin-threshold@link:packages/plugin-threshold":
-  version "0.10.3"
+  version "0.12.0"
   dependencies:
     "@babel/runtime" "^7.7.2"
     "@jimp/utils" "link:packages/utils"
 
 "@jimp/plugins@link:packages/plugins":
-  version "0.10.3"
+  version "0.12.0"
   dependencies:
     "@babel/runtime" "^7.7.2"
     "@jimp/plugin-blit" "link:packages/plugin-blit"
@@ -1205,26 +1205,26 @@
     timm "^1.6.1"
 
 "@jimp/png@link:packages/type-png":
-  version "0.10.3"
+  version "0.12.0"
   dependencies:
     "@babel/runtime" "^7.7.2"
     "@jimp/utils" "link:packages/utils"
     pngjs "^3.3.3"
 
 "@jimp/test-utils@link:packages/test-utils":
-  version "0.10.3"
+  version "0.12.0"
   dependencies:
     "@babel/runtime" "^7.7.2"
     pngjs "^3.3.3"
 
 "@jimp/tiff@link:packages/type-tiff":
-  version "0.10.3"
+  version "0.12.0"
   dependencies:
     "@babel/runtime" "^7.7.2"
     utif "^2.0.1"
 
 "@jimp/types@link:packages/types":
-  version "0.10.3"
+  version "0.12.0"
   dependencies:
     "@babel/runtime" "^7.7.2"
     "@jimp/bmp" "link:packages/type-bmp"
@@ -1235,7 +1235,7 @@
     timm "^1.6.1"
 
 "@jimp/utils@link:packages/utils":
-  version "0.10.3"
+  version "0.12.0"
   dependencies:
     "@babel/runtime" "^7.7.2"
     regenerator-runtime "^0.13.3"
@@ -6814,6 +6814,11 @@ java-properties@^1.0.0:
 jpeg-js@^0.3.4:
   version "0.3.4"
   resolved "https://registry.yarnpkg.com/jpeg-js/-/jpeg-js-0.3.4.tgz#dc2ba501ee3d58b7bb893c5d1fab47294917e7e7"
+
+jpeg-js@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/jpeg-js/-/jpeg-js-0.4.0.tgz#39adab7245b6d11e918ba5d4b49263ff2fc6a2f9"
+  integrity sha512-960VHmtN1vTpasX/1LupLohdP5odwAT7oK/VSm6mW0M58LbrBnowLAPWAZhWGhDAGjzbMnPXZxzB/QYgBwkN0w==
 
 js-levenshtein@^1.1.3:
   version "1.1.6"


### PR DESCRIPTION
# What's Changing and Why

Update jpeg-js w/bug fixes

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.12.1-canary.892.924.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @jimp/cli@0.12.1-canary.892.924.0
  npm install @jimp/core@0.12.1-canary.892.924.0
  npm install @jimp/custom@0.12.1-canary.892.924.0
  npm install jimp@0.12.1-canary.892.924.0
  npm install @jimp/plugin-blit@0.12.1-canary.892.924.0
  npm install @jimp/plugin-blur@0.12.1-canary.892.924.0
  npm install @jimp/plugin-circle@0.12.1-canary.892.924.0
  npm install @jimp/plugin-color@0.12.1-canary.892.924.0
  npm install @jimp/plugin-contain@0.12.1-canary.892.924.0
  npm install @jimp/plugin-cover@0.12.1-canary.892.924.0
  npm install @jimp/plugin-crop@0.12.1-canary.892.924.0
  npm install @jimp/plugin-displace@0.12.1-canary.892.924.0
  npm install @jimp/plugin-dither@0.12.1-canary.892.924.0
  npm install @jimp/plugin-fisheye@0.12.1-canary.892.924.0
  npm install @jimp/plugin-flip@0.12.1-canary.892.924.0
  npm install @jimp/plugin-gaussian@0.12.1-canary.892.924.0
  npm install @jimp/plugin-invert@0.12.1-canary.892.924.0
  npm install @jimp/plugin-mask@0.12.1-canary.892.924.0
  npm install @jimp/plugin-normalize@0.12.1-canary.892.924.0
  npm install @jimp/plugin-print@0.12.1-canary.892.924.0
  npm install @jimp/plugin-resize@0.12.1-canary.892.924.0
  npm install @jimp/plugin-rotate@0.12.1-canary.892.924.0
  npm install @jimp/plugin-scale@0.12.1-canary.892.924.0
  npm install @jimp/plugin-shadow@0.12.1-canary.892.924.0
  npm install @jimp/plugin-threshold@0.12.1-canary.892.924.0
  npm install @jimp/plugins@0.12.1-canary.892.924.0
  npm install @jimp/test-utils@0.12.1-canary.892.924.0
  npm install @jimp/bmp@0.12.1-canary.892.924.0
  npm install @jimp/gif@0.12.1-canary.892.924.0
  npm install @jimp/jpeg@0.12.1-canary.892.924.0
  npm install @jimp/png@0.12.1-canary.892.924.0
  npm install @jimp/tiff@0.12.1-canary.892.924.0
  npm install @jimp/types@0.12.1-canary.892.924.0
  npm install @jimp/utils@0.12.1-canary.892.924.0
  # or 
  yarn add @jimp/cli@0.12.1-canary.892.924.0
  yarn add @jimp/core@0.12.1-canary.892.924.0
  yarn add @jimp/custom@0.12.1-canary.892.924.0
  yarn add jimp@0.12.1-canary.892.924.0
  yarn add @jimp/plugin-blit@0.12.1-canary.892.924.0
  yarn add @jimp/plugin-blur@0.12.1-canary.892.924.0
  yarn add @jimp/plugin-circle@0.12.1-canary.892.924.0
  yarn add @jimp/plugin-color@0.12.1-canary.892.924.0
  yarn add @jimp/plugin-contain@0.12.1-canary.892.924.0
  yarn add @jimp/plugin-cover@0.12.1-canary.892.924.0
  yarn add @jimp/plugin-crop@0.12.1-canary.892.924.0
  yarn add @jimp/plugin-displace@0.12.1-canary.892.924.0
  yarn add @jimp/plugin-dither@0.12.1-canary.892.924.0
  yarn add @jimp/plugin-fisheye@0.12.1-canary.892.924.0
  yarn add @jimp/plugin-flip@0.12.1-canary.892.924.0
  yarn add @jimp/plugin-gaussian@0.12.1-canary.892.924.0
  yarn add @jimp/plugin-invert@0.12.1-canary.892.924.0
  yarn add @jimp/plugin-mask@0.12.1-canary.892.924.0
  yarn add @jimp/plugin-normalize@0.12.1-canary.892.924.0
  yarn add @jimp/plugin-print@0.12.1-canary.892.924.0
  yarn add @jimp/plugin-resize@0.12.1-canary.892.924.0
  yarn add @jimp/plugin-rotate@0.12.1-canary.892.924.0
  yarn add @jimp/plugin-scale@0.12.1-canary.892.924.0
  yarn add @jimp/plugin-shadow@0.12.1-canary.892.924.0
  yarn add @jimp/plugin-threshold@0.12.1-canary.892.924.0
  yarn add @jimp/plugins@0.12.1-canary.892.924.0
  yarn add @jimp/test-utils@0.12.1-canary.892.924.0
  yarn add @jimp/bmp@0.12.1-canary.892.924.0
  yarn add @jimp/gif@0.12.1-canary.892.924.0
  yarn add @jimp/jpeg@0.12.1-canary.892.924.0
  yarn add @jimp/png@0.12.1-canary.892.924.0
  yarn add @jimp/tiff@0.12.1-canary.892.924.0
  yarn add @jimp/types@0.12.1-canary.892.924.0
  yarn add @jimp/utils@0.12.1-canary.892.924.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
