### PR TITLE
Remove 'browser' field from main jimp package's package.json. Fixes:#694

### DIFF
--- a/packages/jimp/package.json
+++ b/packages/jimp/package.json
@@ -4,7 +4,6 @@
   "description": "An image processing library written entirely in JavaScript (i.e. zero external or native dependencies)",
   "main": "dist/index.js",
   "module": "es/index.js",
-  "browser": "browser/lib/jimp.js",
   "types": "types/index.d.ts",
   "typesVersions": {
     ">=3.1.0-0": {


### PR DESCRIPTION
# What's Changing and Why

The `browser` tag in `packages/jimp/package.json` is being removed. It interferes with Browserify's dependency resolution, breaking it and ironically rendering Jimp unusable in Browserify. Meanwhile, building a single JavaScript file for manual inclusion in a webpage remains trivial, as is distributing it, using Browserify.

## What else might be affected

Nothing, which is why I made the decision to simply remove the disruptive field rather than replacing it with something else. Distributing the JavaScript file for clientside (e.g. HTML) inclusion of Jimp is done separately from `npm`, because browsers (and other client-side JavaScript applications) don't use `npm`, which is for server-side applications (i.e. Node.js). That, however, is a concern beyond that of this specific pull request.

## Tasks

- [ ] Add tests
- [ ] Update Documentation
- [ ] Update `jimp.d.ts`
- [ ] Add [SemVer](https://semver.org/) Label
