### PR TITLE
fixed plugin-crop full width slices math

### DIFF
--- a/packages/plugin-crop/src/index.js
+++ b/packages/plugin-crop/src/index.js
@@ -27,7 +27,7 @@ export default function pluginCrop(event) {
     if (x === 0 && w === this.bitmap.width) {
       // shortcut
       const start = (w * y + x) << 2;
-      const end = (start + h * w) << 2;
+      const end = start + (h * w << 2);
 
       this.bitmap.data = this.bitmap.data.slice(start, end);
     } else {


### PR DESCRIPTION
# What's Changing and Why

Fixed how the crop function calculates the slice range size. This bug happens with the 'shortcut' where cropped image-to-be starts from original image x=0, and crop width == original image width.

I have a 96x2048 pixels image from which I'd like to crop out a lot of smaller images (sprites). Original code miscalculates the `end` variable:

```javascript
> f=function(x,y,w,h) {
...       const start = (w * y + x) << 2;
...       const end = (start + h * w) << 2;
...       console.log(end-start)
... }
> f(0,0,96,96)
36864
> f(0,96,96,96)
147456
```
^^ error, this should be 36864 as well

Fixed one:

```javascript
> f=function(x,y,w,h) {
...       const start = (w * y + x) << 2;
...       const end = start + (h * w << 2);
...       console.log(end-start)
... }
> f(0,0,96,96)
36864
> f(0,96,96,96)
36864
```
this is okay.

## What else might be affected

Nothing else (except for any other code that might rely on this bug somehow).

## Tasks

- [ ] Add tests
- [ ] Update Documentation
- [ ] Update `jimp.d.ts`
- [ ] Add [SemVer](https://semver.org/) Label

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.16.2-canary.1073.1276.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @jimp/cli@0.16.2-canary.1073.1276.0
  npm install @jimp/core@0.16.2-canary.1073.1276.0
  npm install @jimp/custom@0.16.2-canary.1073.1276.0
  npm install jimp@0.16.2-canary.1073.1276.0
  npm install @jimp/plugin-blit@0.16.2-canary.1073.1276.0
  npm install @jimp/plugin-blur@0.16.2-canary.1073.1276.0
  npm install @jimp/plugin-circle@0.16.2-canary.1073.1276.0
  npm install @jimp/plugin-color@0.16.2-canary.1073.1276.0
  npm install @jimp/plugin-contain@0.16.2-canary.1073.1276.0
  npm install @jimp/plugin-cover@0.16.2-canary.1073.1276.0
  npm install @jimp/plugin-crop@0.16.2-canary.1073.1276.0
  npm install @jimp/plugin-displace@0.16.2-canary.1073.1276.0
  npm install @jimp/plugin-dither@0.16.2-canary.1073.1276.0
  npm install @jimp/plugin-fisheye@0.16.2-canary.1073.1276.0
  npm install @jimp/plugin-flip@0.16.2-canary.1073.1276.0
  npm install @jimp/plugin-gaussian@0.16.2-canary.1073.1276.0
  npm install @jimp/plugin-invert@0.16.2-canary.1073.1276.0
  npm install @jimp/plugin-mask@0.16.2-canary.1073.1276.0
  npm install @jimp/plugin-normalize@0.16.2-canary.1073.1276.0
  npm install @jimp/plugin-print@0.16.2-canary.1073.1276.0
  npm install @jimp/plugin-resize@0.16.2-canary.1073.1276.0
  npm install @jimp/plugin-rotate@0.16.2-canary.1073.1276.0
  npm install @jimp/plugin-scale@0.16.2-canary.1073.1276.0
  npm install @jimp/plugin-shadow@0.16.2-canary.1073.1276.0
  npm install @jimp/plugin-threshold@0.16.2-canary.1073.1276.0
  npm install @jimp/plugins@0.16.2-canary.1073.1276.0
  npm install @jimp/test-utils@0.16.2-canary.1073.1276.0
  npm install @jimp/bmp@0.16.2-canary.1073.1276.0
  npm install @jimp/gif@0.16.2-canary.1073.1276.0
  npm install @jimp/jpeg@0.16.2-canary.1073.1276.0
  npm install @jimp/png@0.16.2-canary.1073.1276.0
  npm install @jimp/tiff@0.16.2-canary.1073.1276.0
  npm install @jimp/types@0.16.2-canary.1073.1276.0
  npm install @jimp/utils@0.16.2-canary.1073.1276.0
  # or 
  yarn add @jimp/cli@0.16.2-canary.1073.1276.0
  yarn add @jimp/core@0.16.2-canary.1073.1276.0
  yarn add @jimp/custom@0.16.2-canary.1073.1276.0
  yarn add jimp@0.16.2-canary.1073.1276.0
  yarn add @jimp/plugin-blit@0.16.2-canary.1073.1276.0
  yarn add @jimp/plugin-blur@0.16.2-canary.1073.1276.0
  yarn add @jimp/plugin-circle@0.16.2-canary.1073.1276.0
  yarn add @jimp/plugin-color@0.16.2-canary.1073.1276.0
  yarn add @jimp/plugin-contain@0.16.2-canary.1073.1276.0
  yarn add @jimp/plugin-cover@0.16.2-canary.1073.1276.0
  yarn add @jimp/plugin-crop@0.16.2-canary.1073.1276.0
  yarn add @jimp/plugin-displace@0.16.2-canary.1073.1276.0
  yarn add @jimp/plugin-dither@0.16.2-canary.1073.1276.0
  yarn add @jimp/plugin-fisheye@0.16.2-canary.1073.1276.0
  yarn add @jimp/plugin-flip@0.16.2-canary.1073.1276.0
  yarn add @jimp/plugin-gaussian@0.16.2-canary.1073.1276.0
  yarn add @jimp/plugin-invert@0.16.2-canary.1073.1276.0
  yarn add @jimp/plugin-mask@0.16.2-canary.1073.1276.0
  yarn add @jimp/plugin-normalize@0.16.2-canary.1073.1276.0
  yarn add @jimp/plugin-print@0.16.2-canary.1073.1276.0
  yarn add @jimp/plugin-resize@0.16.2-canary.1073.1276.0
  yarn add @jimp/plugin-rotate@0.16.2-canary.1073.1276.0
  yarn add @jimp/plugin-scale@0.16.2-canary.1073.1276.0
  yarn add @jimp/plugin-shadow@0.16.2-canary.1073.1276.0
  yarn add @jimp/plugin-threshold@0.16.2-canary.1073.1276.0
  yarn add @jimp/plugins@0.16.2-canary.1073.1276.0
  yarn add @jimp/test-utils@0.16.2-canary.1073.1276.0
  yarn add @jimp/bmp@0.16.2-canary.1073.1276.0
  yarn add @jimp/gif@0.16.2-canary.1073.1276.0
  yarn add @jimp/jpeg@0.16.2-canary.1073.1276.0
  yarn add @jimp/png@0.16.2-canary.1073.1276.0
  yarn add @jimp/tiff@0.16.2-canary.1073.1276.0
  yarn add @jimp/types@0.16.2-canary.1073.1276.0
  yarn add @jimp/utils@0.16.2-canary.1073.1276.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
