### PR TITLE
Fix edgeHandling types

### DIFF
--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -669,7 +669,7 @@ class Jimp extends EventEmitter {
    * Returns the offset of a pixel in the bitmap buffer
    * @param {number} x the x coordinate
    * @param {number} y the y coordinate
-   * @param {string} edgeHandling (optional) define how to sum pixels from outside the border
+   * @param {number} edgeHandling (optional) define how to sum pixels from outside the border
    * @param {number} cb (optional) a callback for when complete
    * @returns {number} the index of the pixel or -1 if not found
    */

--- a/packages/core/types/jimp.d.ts
+++ b/packages/core/types/jimp.d.ts
@@ -156,7 +156,7 @@ export interface Jimp {
   getPixelIndex(
     x: number,
     y: number,
-    edgeHandling: string,
+    edgeHandling: number,
     cb?: GenericCallback<number, any, this>
   ): number;
   getPixelColor(

--- a/packages/jimp/types/index.d.ts
+++ b/packages/jimp/types/index.d.ts
@@ -147,7 +147,7 @@ interface DepreciatedJimp {
   getPixelIndex(
     x: number,
     y: number,
-    edgeHandling: string,
+    edgeHandling: number,
     cb?: GenericCallback<number, any, this>
   ): number;
   getPixelColor(
@@ -209,7 +209,7 @@ interface DepreciatedJimp {
   convolution(kernel: number[][], cb?: ImageCallback): this;
   convolution<T>(
     kernel: number[][],
-    edgeHandling: string,
+    edgeHandling: number,
     cb?: ImageCallback
   ): this;
   opaque(cb?: ImageCallback): this;

--- a/packages/plugin-color/README.md
+++ b/packages/plugin-color/README.md
@@ -174,7 +174,7 @@ main();
 Sum neighbor pixels weighted by the kernel matrix. You can find a nice explanation with examples at [GIMP's Convolution Matrix plugin](https://docs.gimp.org/2.6/en/plug-in-convmatrix.html)
 
 - @param {array} kernel a matrix to weight the neighbors sum
-- @param {string} edgeHandling (optional) define how to sum pixels from outside the border
+- @param {number} edgeHandling (optional) define how to sum pixels from outside the border
 - @param {function(Error, Jimp)} cb (optional) a callback for when complete
 
 ```js
@@ -183,8 +183,11 @@ import jimp from 'jimp';
 async function main() {
   const image = await jimp.read('test/image.png');
 
-  // make me better
-  image.convolution(weights);
+  image.convolution([
+    [-1, -1, -1],
+    [-1,  8, -1],
+    [-1, -1, -1],
+  ], jimp.EDGE_EXTEND);
 }
 
 main();

--- a/packages/plugin-color/index.d.ts
+++ b/packages/plugin-color/index.d.ts
@@ -27,7 +27,7 @@ interface Color {
   convolution(kernel: number[][], cb?: ImageCallback<this>): this;
   convolution<T>(
     kernel: number[][],
-    edgeHandling: string,
+    edgeHandling: number,
     cb?: ImageCallback<this>
   ): this;
   opaque(cb?: ImageCallback<this>): this;

--- a/packages/plugin-color/src/index.js
+++ b/packages/plugin-color/src/index.js
@@ -350,7 +350,7 @@ export default () => ({
   /**
    * Adds each element of the image to its local neighbors, weighted by the kernel
    * @param {array} kernel a matrix to weight the neighbors sum
-   * @param {string} edgeHandling (optional) define how to sum pixels from outside the border
+   * @param {number} edgeHandling (optional) define how to sum pixels from outside the border
    * @param {function(Error, Jimp)} cb (optional) a callback for when complete
    * @returns {Jimp }this for chaining of methods
    */


### PR DESCRIPTION
# What's Changing and Why

Fixes the edgeHandling type definitions and documentation around convolution.

Why is number correct?
- Only used in convolution to call getPixelIndex https://github.com/oliver-moran/jimp/blob/53ff9d1266207f7f674233f465ec358274510511/packages/plugin-color/src/index.js#L400
- getPixelIndex only compares this against constants https://github.com/oliver-moran/jimp/blob/53ff9d1266207f7f674233f465ec358274510511/packages/core/src/index.js#L699-L722
- These constants are numbers https://github.com/oliver-moran/jimp/blob/53ff9d1266207f7f674233f465ec358274510511/packages/core/src/constants.js#L26-L29

A future improvement may be to make all functions that expect constants to be typed to only accept those constants. But I think that's beyond the scope of this PR for now.

I have also updated the documentation that preivously had a comment 'make me better' to give a more practical example of how to call the convolution method.

## Tasks

- [ ] Add tests: Not done because just updating docs and types (and there are no type tests as far as I can see)
- [x] Update Documentation
- [x] Update `jimp.d.ts`
- [ ] Add [SemVer](https://semver.org/) Label: Happy to add in PR, but assumed library maintainers would want to do that centrally to avoid conflicts?
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.16.2-canary.1080.1288.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install @jimp/cli@0.16.2-canary.1080.1288.0
  npm install @jimp/core@0.16.2-canary.1080.1288.0
  npm install @jimp/custom@0.16.2-canary.1080.1288.0
  npm install jimp@0.16.2-canary.1080.1288.0
  npm install @jimp/plugin-blit@0.16.2-canary.1080.1288.0
  npm install @jimp/plugin-blur@0.16.2-canary.1080.1288.0
  npm install @jimp/plugin-circle@0.16.2-canary.1080.1288.0
  npm install @jimp/plugin-color@0.16.2-canary.1080.1288.0
  npm install @jimp/plugin-contain@0.16.2-canary.1080.1288.0
  npm install @jimp/plugin-cover@0.16.2-canary.1080.1288.0
  npm install @jimp/plugin-crop@0.16.2-canary.1080.1288.0
  npm install @jimp/plugin-displace@0.16.2-canary.1080.1288.0
  npm install @jimp/plugin-dither@0.16.2-canary.1080.1288.0
  npm install @jimp/plugin-fisheye@0.16.2-canary.1080.1288.0
  npm install @jimp/plugin-flip@0.16.2-canary.1080.1288.0
  npm install @jimp/plugin-gaussian@0.16.2-canary.1080.1288.0
  npm install @jimp/plugin-invert@0.16.2-canary.1080.1288.0
  npm install @jimp/plugin-mask@0.16.2-canary.1080.1288.0
  npm install @jimp/plugin-normalize@0.16.2-canary.1080.1288.0
  npm install @jimp/plugin-print@0.16.2-canary.1080.1288.0
  npm install @jimp/plugin-resize@0.16.2-canary.1080.1288.0
  npm install @jimp/plugin-rotate@0.16.2-canary.1080.1288.0
  npm install @jimp/plugin-scale@0.16.2-canary.1080.1288.0
  npm install @jimp/plugin-shadow@0.16.2-canary.1080.1288.0
  npm install @jimp/plugin-threshold@0.16.2-canary.1080.1288.0
  npm install @jimp/plugins@0.16.2-canary.1080.1288.0
  npm install @jimp/test-utils@0.16.2-canary.1080.1288.0
  npm install @jimp/bmp@0.16.2-canary.1080.1288.0
  npm install @jimp/gif@0.16.2-canary.1080.1288.0
  npm install @jimp/jpeg@0.16.2-canary.1080.1288.0
  npm install @jimp/png@0.16.2-canary.1080.1288.0
  npm install @jimp/tiff@0.16.2-canary.1080.1288.0
  npm install @jimp/types@0.16.2-canary.1080.1288.0
  npm install @jimp/utils@0.16.2-canary.1080.1288.0
  # or 
  yarn add @jimp/cli@0.16.2-canary.1080.1288.0
  yarn add @jimp/core@0.16.2-canary.1080.1288.0
  yarn add @jimp/custom@0.16.2-canary.1080.1288.0
  yarn add jimp@0.16.2-canary.1080.1288.0
  yarn add @jimp/plugin-blit@0.16.2-canary.1080.1288.0
  yarn add @jimp/plugin-blur@0.16.2-canary.1080.1288.0
  yarn add @jimp/plugin-circle@0.16.2-canary.1080.1288.0
  yarn add @jimp/plugin-color@0.16.2-canary.1080.1288.0
  yarn add @jimp/plugin-contain@0.16.2-canary.1080.1288.0
  yarn add @jimp/plugin-cover@0.16.2-canary.1080.1288.0
  yarn add @jimp/plugin-crop@0.16.2-canary.1080.1288.0
  yarn add @jimp/plugin-displace@0.16.2-canary.1080.1288.0
  yarn add @jimp/plugin-dither@0.16.2-canary.1080.1288.0
  yarn add @jimp/plugin-fisheye@0.16.2-canary.1080.1288.0
  yarn add @jimp/plugin-flip@0.16.2-canary.1080.1288.0
  yarn add @jimp/plugin-gaussian@0.16.2-canary.1080.1288.0
  yarn add @jimp/plugin-invert@0.16.2-canary.1080.1288.0
  yarn add @jimp/plugin-mask@0.16.2-canary.1080.1288.0
  yarn add @jimp/plugin-normalize@0.16.2-canary.1080.1288.0
  yarn add @jimp/plugin-print@0.16.2-canary.1080.1288.0
  yarn add @jimp/plugin-resize@0.16.2-canary.1080.1288.0
  yarn add @jimp/plugin-rotate@0.16.2-canary.1080.1288.0
  yarn add @jimp/plugin-scale@0.16.2-canary.1080.1288.0
  yarn add @jimp/plugin-shadow@0.16.2-canary.1080.1288.0
  yarn add @jimp/plugin-threshold@0.16.2-canary.1080.1288.0
  yarn add @jimp/plugins@0.16.2-canary.1080.1288.0
  yarn add @jimp/test-utils@0.16.2-canary.1080.1288.0
  yarn add @jimp/bmp@0.16.2-canary.1080.1288.0
  yarn add @jimp/gif@0.16.2-canary.1080.1288.0
  yarn add @jimp/jpeg@0.16.2-canary.1080.1288.0
  yarn add @jimp/png@0.16.2-canary.1080.1288.0
  yarn add @jimp/tiff@0.16.2-canary.1080.1288.0
  yarn add @jimp/types@0.16.2-canary.1080.1288.0
  yarn add @jimp/utils@0.16.2-canary.1080.1288.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
