### PR TITLE
Bump jpeg-js over 0.4.4 to avoid cve-2022-25851

### DIFF
--- a/packages/type-jpeg/package.json
+++ b/packages/type-jpeg/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@babel/runtime": "^7.7.2",
     "@jimp/utils": "link:../utils",
-    "jpeg-js": "0.4.2"
+    "jpeg-js": "^0.4.2"
   },
   "peerDependencies": {
     "@jimp/custom": ">=0.3.5"


### PR DESCRIPTION
# What's Changing and Why

Change dependency on jpeg-js from 0.4.2 to ^0.4.4 to avoid https://avd.aquasec.com/nvd/2022/cve-2022-25851/ is present on 0.4.2

