### PR TITLE
fix: load bitmap font fail in browser

### DIFF
--- a/plugins/plugin-print/src/load-bitmap-font.ts
+++ b/plugins/plugin-print/src/load-bitmap-font.ts
@@ -157,9 +157,15 @@ export async function processBitmapFont(file: string, font: LoadedFont) {
     chars,
     kernings,
     pages: await Promise.all(
-      font.pages.map(async (page) =>
-        CharacterJimp.read(path.join(path.dirname(file), page))
-      )
+      font.pages.map(async (page) => {
+        let fileUrl = ''
+        if (file.startsWith('http')) {
+          fileUrl = new URL(page, file).toString()
+        } else {
+          fileUrl = path.join(path.dirname(file), page)
+        }
+        return CharacterJimp.read(fileUrl)
+      })
     ),
   };
 }


### PR DESCRIPTION
Jimp supports loading fonts from URLs, but on the browser, I found that it performs abnormally under non localhost domains. 

Then I found that there was a problem with the following line of code,
https://github.com/jimp-dev/jimp/blob/b6b0e418a5f1259211a133b20cddb4f4e5c25679/plugins/plugin-print/src/load-bitmap-font.ts#L161

and it will eventually construct a similar one `https:/raw.githubusercontent.com/jimp-dev/jimp/main/plugins/plugin-print/fonts/open-sans/open-sans-16-black/open-sans-16-black.png`  

The link clearly shows that there is a missing '/' after 'https'.