### PR TITLE
Update file-type from ^16 to ^21.3.3 in @jimp/core

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,7 +20,7 @@
     "@jimp/utils": "workspace:*",
     "await-to-js": "^3.0.0",
     "exif-parser": "^0.1.12",
-    "file-type": "^21.3.1",
+    "file-type": "^21.3.3",
     "mime": "3"
   },
   "devDependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,14 +20,14 @@
     "@jimp/utils": "workspace:*",
     "await-to-js": "^3.0.0",
     "exif-parser": "^0.1.12",
-    "file-type": "^16.0.0",
+    "file-type": "^21.3.1",
     "mime": "3"
   },
   "devDependencies": {
     "@jimp/config-eslint": "workspace:*",
     "@jimp/config-typescript": "workspace:*",
     "@jimp/test-utils": "workspace:*",
-    "@types/file-type": "^10.9.1",
+
     "@types/mime": "^3.0.4",
     "@types/node": "^18.19.48",
     "eslint": "^9.9.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -27,7 +27,6 @@
     "@jimp/config-eslint": "workspace:*",
     "@jimp/config-typescript": "workspace:*",
     "@jimp/test-utils": "workspace:*",
-
     "@types/mime": "^3.0.4",
     "@types/node": "^18.19.48",
     "eslint": "^9.9.1",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,6 @@
 import { Bitmap, Format, JimpClass, Edge } from "@jimp/types";
 import { cssColorToHex, scan, scanIterator } from "@jimp/utils";
-import fileType from "file-type/core.js";
+import { fileTypeFromBuffer } from "file-type/core.js";
 import { to } from "await-to-js";
 import { existsSync, readFile, writeFile } from "@jimp/file-ops";
 import mime from "mime/lite.js";
@@ -334,7 +334,7 @@ export function createJimp<
       const actualBuffer =
         buffer instanceof ArrayBuffer ? bufferFromArrayBuffer(buffer) : buffer;
 
-      const mime = await fileType.fromBuffer(actualBuffer);
+      const mime = await fileTypeFromBuffer(actualBuffer);
 
       if (!mime || !mime.mime) {
         throw new Error("Could not find MIME for Buffer");

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,5 @@
 import { Bitmap, Format, JimpClass, Edge } from "@jimp/types";
 import { cssColorToHex, scan, scanIterator } from "@jimp/utils";
-import { fileTypeFromBuffer } from "file-type/core.js";
 import { to } from "await-to-js";
 import { existsSync, readFile, writeFile } from "@jimp/file-ops";
 import mime from "mime/lite.js";
@@ -27,6 +26,15 @@ function bufferFromArrayBuffer(arrayBuffer: ArrayBuffer) {
   }
 
   return buffer;
+}
+
+async function detectFileTypeFromBuffer(buffer: Buffer | ArrayBuffer) {
+  const { fileTypeFromBuffer } = await import("file-type");
+  return fileTypeFromBuffer(
+    buffer instanceof ArrayBuffer
+      ? buffer
+      : new Uint8Array(buffer.buffer, buffer.byteOffset, buffer.byteLength)
+  );
 }
 
 export { getExifOrientation } from "./utils/image-bitmap.js";
@@ -334,7 +342,7 @@ export function createJimp<
       const actualBuffer =
         buffer instanceof ArrayBuffer ? bufferFromArrayBuffer(buffer) : buffer;
 
-      const mime = await fileTypeFromBuffer(actualBuffer);
+      const mime = await detectFileTypeFromBuffer(actualBuffer);
 
       if (!mime || !mime.mime) {
         throw new Error("Could not find MIME for Buffer");

--- a/plugins/plugin-quantize/src/index.ts
+++ b/plugins/plugin-quantize/src/index.ts
@@ -59,7 +59,7 @@ export const methods = {
     } = QuantizeOptionsSchema.parse(options);
 
     const inPointContainer = utils.PointContainer.fromUint8Array(
-      image.bitmap.data,
+      new Uint8Array(image.bitmap.data.buffer),
       image.bitmap.width,
       image.bitmap.height
     );

--- a/plugins/wasm-avif/src/index.ts
+++ b/plugins/wasm-avif/src/index.ts
@@ -65,10 +65,10 @@ export default function avif() {
     },
     decode: async (data) => {
       await initDecoder();
-      const result = await decode(data);
+      const result = await decode(new Uint8Array(data).buffer);
 
       return {
-        data: Buffer.from(result.data),
+        data: Buffer.from(new Uint8Array(result.data.buffer, result.data.byteOffset, result.data.byteLength)),
         width: result.width,
         height: result.height,
       };

--- a/plugins/wasm-jpeg/src/index.ts
+++ b/plugins/wasm-jpeg/src/index.ts
@@ -97,10 +97,10 @@ export default function jpeg() {
     },
     decode: async (data) => {
       await initDecoder();
-      const result = await decode(data);
+      const result = await decode(new Uint8Array(data).buffer);
 
       return {
-        data: Buffer.from(result.data),
+        data: Buffer.from(new Uint8Array(result.data.buffer, result.data.byteOffset, result.data.byteLength)),
         width: result.width,
         height: result.height,
       };

--- a/plugins/wasm-png/src/index.ts
+++ b/plugins/wasm-png/src/index.ts
@@ -41,10 +41,10 @@ export default function png() {
     },
     decode: async (data) => {
       await initDecoder();
-      const result = await decode(data);
+      const result = await decode(new Uint8Array(data).buffer);
 
       return {
-        data: Buffer.from(result.data),
+        data: Buffer.from(new Uint8Array(result.data.buffer, result.data.byteOffset, result.data.byteLength)),
         width: result.width,
         height: result.height,
       };

--- a/plugins/wasm-webp/src/index.ts
+++ b/plugins/wasm-webp/src/index.ts
@@ -176,10 +176,10 @@ export default function png() {
     },
     decode: async (data) => {
       await initDecoder();
-      const result = await decode(data);
+      const result = await decode(new Uint8Array(data).buffer);
 
       return {
-        data: Buffer.from(result.data),
+        data: Buffer.from(new Uint8Array(result.data.buffer, result.data.byteOffset, result.data.byteLength)),
         width: result.width,
         height: result.height,
       };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,8 +109,8 @@ importers:
         specifier: ^0.1.12
         version: 0.1.12
       file-type:
-        specifier: ^16.0.0
-        version: 16.5.4
+        specifier: ^21.3.3
+        version: 21.3.3
       mime:
         specifier: '3'
         version: 3.0.0
@@ -124,9 +124,6 @@ importers:
       '@jimp/test-utils':
         specifier: workspace:*
         version: link:../test-utils
-      '@types/file-type':
-        specifier: ^10.9.1
-        version: 10.9.1
       '@types/mime':
         specifier: ^3.0.4
         version: 3.0.4
@@ -2109,6 +2106,9 @@ packages:
     resolution: {integrity: sha512-/l42B1qxpG6RdfYf343Uw1vmDjeNhneUXtzhojE7pDgfpEypmRhI6j1kr17XCVv4Cgl9HdAiQY2x0GwKm7rWCw==}
     engines: {node: '>=6.9.0'}
 
+  '@borewit/text-codec@0.2.2':
+    resolution: {integrity: sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==}
+
   '@bundled-es-modules/cookie@2.0.0':
     resolution: {integrity: sha512-Or6YHg/kamKHpxULAdSqhGqnWFneIXu1NKvvfBBzKGwpVsYuFIQ5aBPHDnnoR3ghW1nvSkALd+EF9iMtY7Vjxw==}
 
@@ -2796,6 +2796,10 @@ packages:
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
 
+  '@tokenizer/inflate@0.4.1':
+    resolution: {integrity: sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==}
+    engines: {node: '>=18'}
+
   '@tokenizer/token@0.3.0':
     resolution: {integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==}
 
@@ -2866,10 +2870,6 @@ packages:
 
   '@types/estree@1.0.5':
     resolution: {integrity: sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==}
-
-  '@types/file-type@10.9.1':
-    resolution: {integrity: sha512-oq0fy8Jqj19HofanFsZ56o5anMDUQtFO9B3wfLqM9o42RyCe1WT+wRbSvRbL2l8ARZXNaJturHk0b442+0yi+g==}
-    deprecated: This is a stub types definition. file-type provides its own type definitions, so you do not need this installed.
 
   '@types/glob@7.2.0':
     resolution: {integrity: sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==}
@@ -3695,6 +3695,15 @@ packages:
       supports-color:
         optional: true
 
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
   decamelize@1.2.0:
     resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
     engines: {node: '>=0.10.0'}
@@ -4074,9 +4083,9 @@ packages:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
 
-  file-type@16.5.4:
-    resolution: {integrity: sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==}
-    engines: {node: '>=10'}
+  file-type@21.3.3:
+    resolution: {integrity: sha512-pNwbwz8c3aZ+GvbJnIsCnDjKvgCZLHxkFWLEFxU3RMa+Ey++ZSEfisvsWQMcdys6PpxQjWUOIDi1fifXsW3YRg==}
+    engines: {node: '>=20'}
 
   fill-range@7.0.1:
     resolution: {integrity: sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==}
@@ -5196,6 +5205,9 @@ packages:
   ms@2.1.2:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
 
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
   msw@2.4.1:
     resolution: {integrity: sha512-HXcoQPzYTwEmVk+BGIcRa0vLabBT+J20SSSeYh/QfajaK5ceA6dlD4ZZjfz2dqGEq4vRNCPLP6eXsB94KllPFg==}
     engines: {node: '>=18'}
@@ -5537,10 +5549,6 @@ packages:
     resolution: {integrity: sha512-iuh7L6jA7JEGu2WxDwtQP1ddOpaJNC4KlDEFfdQajSGgGPNi4OyDc2R7QnbY2bR9QjBVGwgvTdNJZoE7RaxUMA==}
     engines: {node: '>=0.12'}
 
-  peek-readable@4.1.0:
-    resolution: {integrity: sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg==}
-    engines: {node: '>=8'}
-
   pegjs@0.10.0:
     resolution: {integrity: sha512-qI5+oFNEGi3L5HAxDwN2LA4Gg7irF70Zs25edhjld9QemOgp0CbvMtbFcMvFtEo1OityPrcCzkQFB8JP/hxgow==}
     engines: {node: '>=0.10'}
@@ -5749,10 +5757,6 @@ packages:
   readable-stream@3.6.2:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
-
-  readable-web-to-node-stream@3.0.2:
-    resolution: {integrity: sha512-ePeK6cc1EcKLEhJFt/AebMCLL+GgSKhuygrZ/GLaKZYEecIgIECf4UaUuaByiGtzckwR4ain9VzUh95T1exYGw==}
-    engines: {node: '>=8'}
 
   readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
@@ -6232,9 +6236,9 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
-  strtok3@6.3.0:
-    resolution: {integrity: sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw==}
-    engines: {node: '>=10'}
+  strtok3@10.3.4:
+    resolution: {integrity: sha512-KIy5nylvC5le1OdaaoCJ07L+8iQzJHGH6pWDuzS+d07Cu7n1MZ2x26P8ZKIWfbK02+XIL8Mp4RkWeqdUCrDMfg==}
+    engines: {node: '>=18'}
 
   style-to-object@0.4.4:
     resolution: {integrity: sha512-HYNoHZa2GorYNyqiCaBgsxvcJIn7OHq6inEga+E6Ke3m5JkoqpQbnFssk4jwe+K7AhGa2fcha4wSOf1Kn01dMg==}
@@ -6332,9 +6336,9 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
-  token-types@4.2.1:
-    resolution: {integrity: sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ==}
-    engines: {node: '>=10'}
+  token-types@6.1.2:
+    resolution: {integrity: sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==}
+    engines: {node: '>=14.16'}
 
   totalist@3.0.1:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
@@ -6529,6 +6533,10 @@ packages:
     resolution: {integrity: sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==}
     engines: {node: '>=0.8.0'}
     hasBin: true
+
+  uint8array-extras@1.5.0:
+    resolution: {integrity: sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==}
+    engines: {node: '>=18'}
 
   ultrahtml@1.5.3:
     resolution: {integrity: sha512-GykOvZwgDWZlTQMtp5jrD4BVL+gNn2NVlVafjcFUJ7taY20tqYdwdoWBFy6GBJsNTZe1GkGPkSl5knQAjtgceg==}
@@ -7352,7 +7360,7 @@ snapshots:
       '@babel/traverse': 7.25.6
       '@babel/types': 7.25.6
       convert-source-map: 2.0.0
-      debug: 4.3.4
+      debug: 4.3.6
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -7498,6 +7506,8 @@ snapshots:
       '@babel/helper-string-parser': 7.24.8
       '@babel/helper-validator-identifier': 7.24.7
       to-fast-properties: 2.0.0
+
+  '@borewit/text-codec@0.2.2': {}
 
   '@bundled-es-modules/cookie@2.0.0':
     dependencies:
@@ -8162,6 +8172,13 @@ snapshots:
     dependencies:
       '@testing-library/dom': 10.4.0
 
+  '@tokenizer/inflate@0.4.1':
+    dependencies:
+      debug: 4.4.3
+      token-types: 6.1.2
+    transitivePeerDependencies:
+      - supports-color
+
   '@tokenizer/token@0.3.0': {}
 
   '@tootallnate/quickjs-emscripten@0.23.0': {}
@@ -8262,10 +8279,6 @@ snapshots:
       '@types/estree': 1.0.5
 
   '@types/estree@1.0.5': {}
-
-  '@types/file-type@10.9.1':
-    dependencies:
-      file-type: 16.5.4
 
   '@types/glob@7.2.0':
     dependencies:
@@ -8504,23 +8517,6 @@ snapshots:
       - graphql
       - typescript
       - utf-8-validate
-
-  '@vitest/browser@2.0.5(typescript@5.5.4)(vitest@2.0.5)':
-    dependencies:
-      '@testing-library/dom': 10.4.0
-      '@testing-library/user-event': 14.5.2(@testing-library/dom@10.4.0)
-      '@vitest/utils': 2.0.5
-      magic-string: 0.30.11
-      msw: 2.4.1(typescript@5.5.4)
-      sirv: 2.0.4
-      vitest: 2.0.5(@types/node@18.19.48)(@vitest/browser@2.0.5)(terser@5.30.3)
-      ws: 8.18.0
-    transitivePeerDependencies:
-      - bufferutil
-      - graphql
-      - typescript
-      - utf-8-validate
-    optional: true
 
   '@vitest/expect@2.0.5':
     dependencies:
@@ -9339,6 +9335,10 @@ snapshots:
     dependencies:
       ms: 2.1.2
 
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
   decamelize@1.2.0: {}
 
   decode-named-character-reference@1.0.2:
@@ -9826,11 +9826,14 @@ snapshots:
     dependencies:
       flat-cache: 4.0.1
 
-  file-type@16.5.4:
+  file-type@21.3.3:
     dependencies:
-      readable-web-to-node-stream: 3.0.2
-      strtok3: 6.3.0
-      token-types: 4.2.1
+      '@tokenizer/inflate': 0.4.1
+      strtok3: 10.3.4
+      token-types: 6.1.2
+      uint8array-extras: 1.5.0
+    transitivePeerDependencies:
+      - supports-color
 
   fill-range@7.0.1:
     dependencies:
@@ -11384,6 +11387,8 @@ snapshots:
 
   ms@2.1.2: {}
 
+  ms@2.1.3: {}
+
   msw@2.4.1(typescript@5.5.4):
     dependencies:
       '@bundled-es-modules/cookie': 2.0.0
@@ -11785,8 +11790,6 @@ snapshots:
       safe-buffer: 5.2.1
       sha.js: 2.4.11
 
-  peek-readable@4.1.0: {}
-
   pegjs@0.10.0: {}
 
   periscopic@3.1.0:
@@ -11987,10 +11990,6 @@ snapshots:
       inherits: 2.0.4
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
-
-  readable-web-to-node-stream@3.0.2:
-    dependencies:
-      readable-stream: 3.6.2
 
   readdirp@3.6.0:
     dependencies:
@@ -12586,10 +12585,9 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
-  strtok3@6.3.0:
+  strtok3@10.3.4:
     dependencies:
       '@tokenizer/token': 0.3.0
-      peek-readable: 4.1.0
 
   style-to-object@0.4.4:
     dependencies:
@@ -12688,8 +12686,9 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
-  token-types@4.2.1:
+  token-types@6.1.2:
     dependencies:
+      '@borewit/text-codec': 0.2.2
       '@tokenizer/token': 0.3.0
       ieee754: 1.2.1
 
@@ -12881,6 +12880,8 @@ snapshots:
 
   uglify-js@3.17.4:
     optional: true
+
+  uint8array-extras@1.5.0: {}
 
   ultrahtml@1.5.3: {}
 
@@ -13144,7 +13145,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 18.19.48
-      '@vitest/browser': 2.0.5(typescript@5.5.4)(vitest@2.0.5)
+      '@vitest/browser': 2.0.5(playwright@1.46.1)(typescript@5.5.4)(vitest@2.0.5)
     transitivePeerDependencies:
       - less
       - lightningcss
@@ -13178,7 +13179,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.5.2
-      '@vitest/browser': 2.0.5(typescript@5.5.4)(vitest@2.0.5)
+      '@vitest/browser': 2.0.5(playwright@1.46.1)(typescript@5.5.4)(vitest@2.0.5)
     transitivePeerDependencies:
       - less
       - lightningcss


### PR DESCRIPTION
## Summary

Fixes #1399

Updates the `file-type` dependency in `@jimp/core` from `^16.0.0` to `^21.3.1` to address the security vulnerability [GHSA-5v7r-6r5c-r473](https://github.com/advisories/GHSA-5v7r-6r5c-r473) (CVE-2024-4367), which affects `file-type` versions `<16.5.4` and `<18.7.0`.

### Changes

- **`packages/core/package.json`**: Bump `file-type` from `^16.0.0` to `^21.3.1`; remove deprecated `@types/file-type` dev dependency (types are now bundled in `file-type` itself)
- **`packages/core/src/index.ts`**: Update import from default export (`import fileType from "file-type/core.js"`) to named export (`import { fileTypeFromBuffer } from "file-type/core.js"`), and replace `fileType.fromBuffer(...)` with `fileTypeFromBuffer(...)`

### Notes

- `file-type` v21 is ESM-only, which is compatible with `@jimp/core` since it already uses `"type": "module"` and builds with `tshy`
- The `@types/file-type` package is deprecated as `file-type` now ships its own type definitions
- Only source files are modified; dist files should be rebuilt by maintainers