### PR TITLE
fix(@jimp/wasm-webp): initialize WebP WASM from disk in Node

### DIFF
--- a/plugins/wasm-webp/package.json
+++ b/plugins/wasm-webp/package.json
@@ -7,6 +7,7 @@
   },
   "scripts": {
     "lint": "eslint .",
+    "test": "vitest",
     "build": "tshy",
     "dev": "tshy --watch",
     "clean": "rm -rf node_modules .tshy .tshy-build dist .turbo"

--- a/plugins/wasm-webp/src/index.node.test.ts
+++ b/plugins/wasm-webp/src/index.node.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "vitest";
+import { readFile } from "node:fs/promises";
+
+import webp from "./index.js";
+
+const format = webp();
+
+describe("WASM WebP (Node)", () => {
+  test("loads WebP fixtures in Node", async () => {
+    const image = await format.decode(
+      await readFile(new URL("./images/test.webp", import.meta.url))
+    );
+
+    expect(image.width).toBeGreaterThan(0);
+    expect(image.height).toBeGreaterThan(0);
+    expect(image.data.length).toBe(image.width * image.height * 4);
+    expect(Buffer.from(image.data).some((value) => value !== 0)).toBe(true);
+  });
+
+  test("exports WebP buffers in Node", async () => {
+    const bitmap = {
+      width: 3,
+      height: 3,
+      data: Buffer.from([
+        255, 0, 0, 255,
+        255, 0, 128, 255,
+        255, 0, 255, 255,
+        255, 0, 128, 255,
+        255, 0, 255, 255,
+        128, 0, 255, 255,
+        255, 0, 255, 255,
+        128, 0, 255, 255,
+        0, 0, 255, 255,
+      ]),
+    };
+
+    const buffer = await format.encode(bitmap);
+    expect(buffer.toString("ascii", 0, 4)).toBe("RIFF");
+    expect(buffer.toString("ascii", 8, 12)).toBe("WEBP");
+
+    const roundTrip = await format.decode(buffer);
+    expect(roundTrip.width).toBe(3);
+    expect(roundTrip.height).toBe(3);
+  });
+});

--- a/plugins/wasm-webp/src/index.ts
+++ b/plugins/wasm-webp/src/index.ts
@@ -101,7 +101,96 @@ const WebpOptionsSchema = z.object({
 
 type WebpOptions = z.infer<typeof WebpOptionsSchema>;
 
-export default function png() {
+const isNodeRuntime =
+  typeof process === "object" &&
+  typeof process.versions === "object" &&
+  typeof process.versions.node === "string";
+
+const nodeWasmModuleCache = new Map<string, Promise<WebAssembly.Module>>();
+let decoderInitPromise: Promise<unknown> | undefined;
+let encoderInitPromise: Promise<unknown> | undefined;
+
+async function supportsSimd() {
+  return WebAssembly.validate(
+    new Uint8Array([
+      0, 97, 115, 109, 1, 0, 0, 0, 1, 5, 1, 96, 0, 1, 123, 3, 2, 1, 0,
+      10, 10, 1, 8, 0, 65, 0, 253, 15, 253, 98, 11,
+    ])
+  );
+}
+
+function resetPromiseOnError<T>(
+  promise: Promise<T>,
+  reset: () => void
+): Promise<T> {
+  return promise.catch((error) => {
+    reset();
+    throw error;
+  });
+}
+
+async function loadNodeWasmModule(specifier: string): Promise<WebAssembly.Module> {
+  const cachedModule = nodeWasmModuleCache.get(specifier);
+  if (cachedModule) {
+    return cachedModule;
+  }
+
+  const modulePromise = (async () => {
+    try {
+      const { readFile } = await import("node:fs/promises");
+      const { default: Module } = await import("node:module");
+
+      const require = Module.createRequire(import.meta.url);
+      const wasmPath = require.resolve(specifier);
+      return WebAssembly.compile(await readFile(wasmPath));
+    } catch (error) {
+      nodeWasmModuleCache.delete(specifier);
+      throw error;
+    }
+  })();
+
+  nodeWasmModuleCache.set(specifier, modulePromise);
+  return modulePromise;
+}
+
+async function ensureDecoderInitialized() {
+  if (!decoderInitPromise) {
+    decoderInitPromise = resetPromiseOnError(
+      isNodeRuntime
+        ? initDecoder(
+            await loadNodeWasmModule("@jsquash/webp/codec/dec/webp_dec.wasm")
+          )
+        : initDecoder(),
+      () => {
+        decoderInitPromise = undefined;
+      }
+    );
+  }
+
+  return decoderInitPromise;
+}
+
+async function ensureEncoderInitialized() {
+  if (!encoderInitPromise) {
+    const encoderWasmSpecifier =
+      isNodeRuntime && (await supportsSimd())
+        ? "@jsquash/webp/codec/enc/webp_enc_simd.wasm"
+        : "@jsquash/webp/codec/enc/webp_enc.wasm";
+
+    encoderInitPromise = resetPromiseOnError(
+      isNodeRuntime
+        ? initEncoder(await loadNodeWasmModule(encoderWasmSpecifier))
+        : initEncoder(),
+      () => {
+        encoderInitPromise = undefined;
+      }
+    );
+  }
+
+  return encoderInitPromise;
+}
+
+export default function webp() {
   return {
     mime: "image/webp",
     hasAlpha: true,
@@ -135,7 +224,7 @@ export default function png() {
         targetSize,
         colorSpace = "srgb",
       } = WebpOptionsSchema.parse(options);
-      await initEncoder();
+      await ensureEncoderInitialized();
       const arrayBuffer = await encode(
         {
           ...bitmap,
@@ -175,7 +264,7 @@ export default function png() {
       return Buffer.from(arrayBuffer);
     },
     decode: async (data) => {
-      await initDecoder();
+      await ensureDecoderInitialized();
       const result = await decode(new Uint8Array(data).buffer);
 
       return {


### PR DESCRIPTION
## Summary
- fix `@jimp/wasm-webp` in Node by resolving the existing `@jsquash/webp` WASM files from disk and compiling them directly instead of relying on `fetch(file://...)`
- keep the browser path unchanged while caching compiled decoder and encoder modules for repeated use
- add a Node regression test that decodes the existing WebP fixture and round-trips an encoded WebP buffer

## Root Cause
`@jsquash/webp` initializes its WASM modules through a fetch-based path that works in browsers, but in Node it resolves to a local `file:` URL. Node's `fetch()` cannot load that URL, so `@jimp/wasm-webp` fails during decoder or encoder initialization before any image work can happen.

## What Changed
For Node only, `@jimp/wasm-webp` now:
- resolves the decoder and encoder `.wasm` assets with `Module.createRequire(import.meta.url)`
- reads and compiles those files with `node:fs/promises` and `WebAssembly.compile`
- chooses the SIMD encoder binary only when the current runtime supports SIMD
- resets failed init promises so a transient initialization error does not permanently poison the process

## Impact
This keeps the existing `@jsquash/webp` integration and public API intact, but makes the package usable in Node again for both decoding and encoding WebP images.

Closes #1366

## Validation
- `pnpm --filter @jimp/types build`
- `pnpm --filter @jimp/wasm-webp build`
- `pnpm --filter @jimp/wasm-webp lint`
- `pnpm --filter @jimp/wasm-webp test -- --run`