### PR TITLE
docs: update v1 options examples

### DIFF
--- a/packages/jimp/README.md
+++ b/packages/jimp/README.md
@@ -35,7 +35,7 @@ const { Jimp } = require("jimp");
 // open a file called "lenna.png"
 const image = await Jimp.read("test.png");
 
-image.resize(256, 256); // resize
+image.resize({ w: 256, h: 256 }); // resize
 
 await image.write("test-small.jpg"); // save
 ```

--- a/packages/jimp/src/index.ts
+++ b/packages/jimp/src/index.ts
@@ -101,7 +101,7 @@ export const JimpMime = {
  *
  * const image = await Jimp.read("test/image.png");
  *
- * image.resize(256, 100);
+ * image.resize({ w: 256, h: 100 });
  * image.greyscale();
  *
  * await image.write('test/output.png');
@@ -116,7 +116,7 @@ export const JimpMime = {
  *
  * const image = await Jimp.read("https://upload.wikimedia.org/wikipedia/commons/0/01/Bot-Test.jpg");
  *
- * image.resize(256, 100);
+ * image.resize({ w: 256, h: 100 });
  * image.greyscale();
  *
  * const output = await image.getBuffer("test/image.png");

--- a/plugins/plugin-flip/src/index.ts
+++ b/plugins/plugin-flip/src/index.ts
@@ -13,15 +13,14 @@ export type FlipOptions = z.infer<typeof FlipOptionsSchema>;
 export const methods = {
   /**
    * Flip the image.
-   * @param horizontal a Boolean, if true the image will be flipped horizontally
-   * @param vertical a Boolean, if true the image will be flipped vertically
+   * @param options an object with horizontal and vertical booleans
    * @example
    * ```ts
    * import { Jimp } from "jimp";
    *
    * const image = await Jimp.read("test/image.png");
    *
-   * image.flip(true, false);
+   * image.flip({ horizontal: true, vertical: false });
    * ```
    */
   flip<I extends JimpClass>(image: I, options: FlipOptions) {


### PR DESCRIPTION
# What's Changing and Why

Updates Jimp v1 documentation examples that still showed pre-v1 positional method arguments:

- `flip(true, false)` now uses `flip({ horizontal: true, vertical: false })`.
- `resize(256, 100)` and `resize(256, 256)` examples now use `{ w, h }` options objects.

This matches the current v1 API and addresses the stale docs reported in #1389.

## What else might be affected

Documentation/example output only. Runtime code is unchanged.

## Tasks

- [ ] Add tests
- [x] Update Documentation
- [ ] Update `jimp.d.ts`
- [ ] Add [SemVer](https://semver.org/) Label

Validation:

- `git diff --check`
- `npx --yes prettier@3.3.3 --check plugins/plugin-flip/src/index.ts packages/jimp/src/index.ts packages/jimp/README.md`

Closes #1389
