### PR TITLE
fix(blit): preserve source colors over transparency

### DIFF
--- a/plugins/plugin-blit/src/index.test.ts
+++ b/plugins/plugin-blit/src/index.test.ts
@@ -69,4 +69,21 @@ describe("Blit over image", function () {
       targetImg.clone().blit({ src: srcImg, x: 3, y: 3 }),
     ).toMatchSnapshot();
   });
+
+  test("blit preserves source colors over transparent pixels", () => {
+    const target = Jimp.fromBitmap({
+      width: 1,
+      height: 1,
+      data: new Uint8Array([0, 0, 0, 0]),
+    });
+    const source = Jimp.fromBitmap({
+      width: 1,
+      height: 1,
+      data: new Uint8Array([255, 255, 255, 128]),
+    });
+
+    target.blit(source);
+
+    expect(Array.from(target.bitmap.data)).toEqual([255, 255, 255, 128]);
+  });
 });

--- a/plugins/plugin-blit/src/index.ts
+++ b/plugins/plugin-blit/src/index.ts
@@ -99,13 +99,30 @@ export const methods = {
           a: image.bitmap.data[dstIdx + 3] || 0,
         };
 
-        image.bitmap.data[dstIdx] =
-          ((srcColor.a * (srcColor.r - dst.r) - dst.r + 255) >> 8) + dst.r;
-        image.bitmap.data[dstIdx + 1] =
-          ((srcColor.a * (srcColor.g - dst.g) - dst.g + 255) >> 8) + dst.g;
-        image.bitmap.data[dstIdx + 2] =
-          ((srcColor.a * (srcColor.b - dst.b) - dst.b + 255) >> 8) + dst.b;
-        image.bitmap.data[dstIdx + 3] = limit255(dst.a + srcColor.a);
+        const srcAlpha = srcColor.a / 255;
+        const dstAlpha = dst.a / 255;
+        const outAlpha = srcAlpha + dstAlpha * (1 - srcAlpha);
+
+        if (outAlpha === 0) {
+          image.bitmap.data[dstIdx] = 0;
+          image.bitmap.data[dstIdx + 1] = 0;
+          image.bitmap.data[dstIdx + 2] = 0;
+          image.bitmap.data[dstIdx + 3] = 0;
+        } else {
+          image.bitmap.data[dstIdx] = limit255(
+            (srcColor.r * srcAlpha + dst.r * dstAlpha * (1 - srcAlpha)) /
+              outAlpha,
+          );
+          image.bitmap.data[dstIdx + 1] = limit255(
+            (srcColor.g * srcAlpha + dst.g * dstAlpha * (1 - srcAlpha)) /
+              outAlpha,
+          );
+          image.bitmap.data[dstIdx + 2] = limit255(
+            (srcColor.b * srcAlpha + dst.b * dstAlpha * (1 - srcAlpha)) /
+              outAlpha,
+          );
+          image.bitmap.data[dstIdx + 3] = limit255(outAlpha * 255);
+        }
       }
     });
 


### PR DESCRIPTION
## Summary
- use source-over alpha compositing when blitting pixels
- preserve source RGB values when compositing onto fully transparent destinations
- add a regression test for the gray-fringe case from #1072

Fixes #1072.

## Verification
- `git diff --check`
- `node -e "const src={r:255,g:255,b:255,a:128}, dst={r:0,g:0,b:0,a:0}; const sa=src.a/255, da=dst.a/255, oa=sa+da*(1-sa); const c=(s,d)=>(s*sa+d*da*(1-sa))/oa; const actual=[c(src.r,dst.r),c(src.g,dst.g),c(src.b,dst.b),oa*255]; const expected=[255,255,255,128]; if (JSON.stringify(actual)!==JSON.stringify(expected)) { console.error({actual, expected}); process.exit(1); } console.log('alpha compositing regression math ok');"`

I attempted `pnpm --filter @jimp/plugin-blit test -- --watch=false`, but the local dependency link could not complete on this machine because the external SSD ran out of free space (`ERR_PNPM_ENOSPC`).
