### PR TITLE
docs: describe EXIF orientation handling

### DIFF
--- a/packages/docs/src/content/docs/guides/getting-started.mdx
+++ b/packages/docs/src/content/docs/guides/getting-started.mdx
@@ -56,3 +56,22 @@ The workflow for using jimp
    ```
 
 </Steps>
+
+## EXIF orientation
+
+When loading JPEGs, Jimp reads EXIF metadata and automatically rotates the
+bitmap according to the EXIF `Orientation` tag. After rotation, the image is
+treated as normal orientation:
+
+```ts
+import { getExifOrientation } from "@jimp/core";
+import { Jimp } from "jimp";
+
+const image = await Jimp.read("photo.jpg");
+
+console.log(getExifOrientation(image)); // 1 after auto-rotation
+```
+
+Jimp uses EXIF metadata for orientation correction when reading an image. It
+does not provide a public API for editing, adding, copying, or preserving
+arbitrary EXIF tags when writing images.

--- a/packages/jimp/README.md
+++ b/packages/jimp/README.md
@@ -39,3 +39,13 @@ image.resize(256, 256); // resize
 
 await image.write("test-small.jpg"); // save
 ```
+
+## EXIF orientation
+
+Jimp automatically applies EXIF orientation when reading JPEG images. You can
+inspect the normalized orientation with `getExifOrientation(image)` from
+`@jimp/core`, which returns `1` after auto-rotation.
+
+Jimp uses EXIF metadata for orientation correction only. It does not expose a
+public API for editing, adding, copying, or preserving arbitrary EXIF tags when
+writing images.


### PR DESCRIPTION
## Summary
- document Jimp's current EXIF orientation behavior in the Getting Started guide
- add the same EXIF orientation note to the package README
- clarify that Jimp does not expose public APIs for arbitrary EXIF tag editing, copying, or preservation when writing images

Fixes #991.

## Verification
- `git diff --check`
- `rg -n "EXIF orientation|arbitrary EXIF|getExifOrientation|@jimp/core" packages/docs/src/content/docs/guides/getting-started.mdx packages/jimp/README.md`

I did not run the full docs build locally because the external SSD is nearly full and the Jimp workspace dependency install has already failed with `ERR_PNPM_ENOSPC` in this checkout.
