### PR TITLE
docs: update crop options example

### DIFF
--- a/plugins/plugin-crop/src/index.ts
+++ b/plugins/plugin-crop/src/index.ts
@@ -41,14 +41,14 @@ export type AutocropOptions = number | AutocropComplexOptions;
 
 export const methods = {
   /**
-   * Crops the image at a given point to a give size.
+   * Crops the image at a given point to a given size.
    *
    * @example
    * ```ts
    * import { Jimp } from "jimp";
    *
    * const image = await Jimp.read("test/image.png");
-   * const cropped = image.crop(150, 100);
+   * const cropped = image.crop({ x: 50, y: 50, w: 150, h: 100 });
    * ```
    */
   crop<I extends JimpClass>(image: I, options: CropOptions) {


### PR DESCRIPTION
## Summary
- update the crop JSDoc example to use the current options-object API
- fix the adjacent wording typo in the crop description

Fixes #972.

## Verification
- `rg -n "image\.crop\(150, 100\)|give size" plugins/plugin-crop/src/index.ts` returned no matches
- `rg -n "image\.crop\(\{ x: 50, y: 50, w: 150, h: 100 \}\)" plugins/plugin-crop/src/index.ts` found the updated example
- `git diff --check`

Note: I did not run the full formatter/test suite locally because this checkout has no `node_modules`, and the current OSC volume is nearly full. `pnpm exec prettier --check plugins/plugin-crop/src/index.ts` attempted to create a pnpm store under the home Library path before it could run.